### PR TITLE
Make sure only files are hashed

### DIFF
--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -71,12 +71,13 @@ class DoxygenRun:
 				# # Code from https://stackoverflow.com/a/22058673/15411117
 				# # BUF_SIZE is totally arbitrary, change for your app!
 				BUF_SIZE = 65536  # lets read stuff in 64kb chunks!
-				with open(path, 'rb') as f:
-					while True:
-						data = f.read(BUF_SIZE)
-						if not data:
-							break
-						sha1.update(data)
+				if path.is_file():
+					with open(path, 'rb') as f:
+						while True:
+							data = f.read(BUF_SIZE)
+							if not data:
+								break
+							sha1.update(data)
 				# print(f"{path}: {sha1.hexdigest()}")
 
 		hahsNew = sha1.hexdigest()


### PR DESCRIPTION
Without this fix directories with . in the name will be matched and the script will crash when it tries to open them.

In my case we have a project where some of the sources are in the repo's root directory, and then the hashing computation matches the `.git` folder which is in the same folder.

Obviously this will cause problems for any folders with a dot in the name if it is within the source folder hierarchy.