### PR TITLE
Add an option `doxygen-bin-path` to specify the path to `doxygen`.

### DIFF
--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -13,7 +13,8 @@ log = logging.getLogger("mkdocs")
 
 
 class DoxygenRun:
-	def __init__(self, doxygenSource: str, tempDoxyFolder: str, doxyCfgNew):
+	def __init__(self, doxygenBinPath: str, doxygenSource: str, tempDoxyFolder: str, doxyCfgNew):
+		self.doxygenBinPath = doxygenBinPath
 		self.doxygenSource = doxygenSource
 		self.tempDoxyFolder = tempDoxyFolder
 		self.doxyCfgNew = doxyCfgNew
@@ -90,7 +91,7 @@ class DoxygenRun:
 		return True
 
 	def run(self):
-		doxyBuilder = Popen(['doxygen', '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+		doxyBuilder = Popen([self.doxygenBinPath, '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
 		stdout_data = doxyBuilder.communicate(self.doxyCfgStr.encode('utf-8'))[0].decode().strip()
 		# log.info(self.destinationDir)
 		# log.info(stdout_data)

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -39,6 +39,7 @@ class MkDoxy(BasePlugin):
 		('ignore-errors', config_options.Type(bool, default=False)),
 		('save-api', config_options.Type(str, default="")),
 		("enabled", config_options.Type(bool, default=True)),
+		("doxygen-bin-path", config_options.Type(str, default="doxygen", required=False)),
 	)
 
 	config_project = (
@@ -95,7 +96,7 @@ class MkDoxy(BasePlugin):
 				tempDirApi = tempDir(config['site_dir'], "assets/.doxy/", projectName)
 
 			# Check scr changes -> run Doxygen
-			doxygenRun = DoxygenRun(self.proData.get('src-dirs'), tempDirApi, self.proData.get('doxy-cfg', {}))
+			doxygenRun = DoxygenRun(self.config['doxygen-bin-path'], self.proData.get('src-dirs'), tempDirApi, self.proData.get('doxy-cfg', {}))
 			if doxygenRun.checkAndRun():
 				log.info("  -> generating Doxygen filese")
 			else:


### PR DESCRIPTION
This commit introduces an option to let the user specify the filepath to the `doxygen` binary.

This option is called `doxygen-bin-path` and can be set in the `mkdocs.yml` under the `mkdoxy` section.

The following snippet is an example of how to use this new option:

```yaml
site_name: My Doc
…

plugins:
  - mkdoxy:
    enabled: !ENV [ENABLE_MKDOXY, True]
    doxygen-bin-path: path/to/doxygen/build/bin/doxygen
    projects:
      mkdoxyApi:
        src-dirs: mkdoxy
        …
```

If not specified, the default value will obviously be `doxygen`.