### PR TITLE
Fix module list indentation

### DIFF
--- a/mkdoxy/templates/modules.jinja2
+++ b/mkdoxy/templates/modules.jinja2
@@ -4,12 +4,12 @@
 {% if nodes|length > 0 %}
 Here is a list of all modules:
 {% for node in nodes recursive %}
-    {% if node.is_group %}
-        * [**{{node.title}}**]({{node.url}}) {{node.brief}}
-        {% if node.has_children %}
-            {{- loop(node.children)|indent(4, true) }}
-        {% endif %}
-    {% endif -%}
+{% if node.is_group %}
+* [**{{node.title}}**]({{node.url}}) {{node.brief}}
+{% if node.has_children %}
+  {{- loop(node.children)|indent(4, true) }}
+{% endif %}
+{% endif -%}
 {% endfor %}
 {% else %}
 No modules found.


### PR DESCRIPTION
The other templates are not indented - for a good reason, the whitespace in the template is rendered into the markdown file. That turns the entire module list into a big code snippet, since it says: 'Here is a list of all modules:' followed by and indented block.