### PR TITLE
Bug fixes when -f flag is used in mkdocs

### DIFF
--- a/mkdoxy/doxygen.py
+++ b/mkdoxy/doxygen.py
@@ -2,8 +2,6 @@ import logging
 import os
 from xml.etree import ElementTree
 
-import path as path
-
 from mkdoxy.cache import Cache
 from mkdoxy.constants import Kind, Visibility
 from mkdoxy.node import Node
@@ -14,7 +12,7 @@ log: logging.Logger = logging.getLogger("mkdocs")
 
 
 class Doxygen:
-	def __init__(self, index_path: path, parser: XmlParser, cache: Cache):
+	def __init__(self, index_path: str, parser: XmlParser, cache: Cache):
 		self.debug = parser.debug
 		path_xml = os.path.join(index_path, 'index.xml')
 		if self.debug:

--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -3,6 +3,7 @@ import logging
 import tempfile
 from pathlib import Path, PurePath
 from subprocess import Popen, PIPE
+from typing import Optional
 
 log: logging.Logger = logging.getLogger("mkdocs")
 
@@ -11,7 +12,7 @@ class DoxygenRun:
 	"""! Class for running Doxygen.
 	@details This class is used to run Doxygen and parse the XML output.
 	"""
-	def __init__(self, doxygenBinPath: str, doxygenSource: str, tempDoxyFolder: str, doxyCfgNew):
+	def __init__(self, doxygenBinPath: str, doxygenSource: str, tempDoxyFolder: str, doxyCfgNew, runPath: Optional[str] = None):
 		"""! Constructor.
 		Default Doxygen config options:
 
@@ -37,6 +38,7 @@ class DoxygenRun:
 		self.doxyCfgNew: dict = doxyCfgNew
 		self.hashFileName: str = "hashChanges.yaml"
 		self.hashFilePath: PurePath = PurePath.joinpath(Path(self.tempDoxyFolder), Path(self.hashFileName))
+		self.runPath: Optional[str] = runPath
 
 		self.doxyCfg: dict = {
 			"INPUT": self.doxygenSource,
@@ -117,7 +119,7 @@ class DoxygenRun:
 		"""! Run Doxygen with the current configuration using the Popen class.
 		@details
 		"""
-		doxyBuilder = Popen([self.doxygenBinPath, '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+		doxyBuilder = Popen([self.doxygenBinPath, '-'], stdout=PIPE, stdin=PIPE, stderr=PIPE, cwd=self.runPath)
 		stdout_data = doxyBuilder.communicate(self.doxyCfgStr.encode('utf-8'))[0].decode().strip()
 		# log.info(self.destinationDir)
 		# log.info(stdout_data)

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -5,6 +5,7 @@ MkDoxy is a MkDocs plugin for generating documentation from Doxygen XML files.
 """
 
 import logging
+import os
 from pathlib import Path, PurePath
 
 from mkdocs import exceptions
@@ -111,7 +112,8 @@ class MkDoxy(BasePlugin):
 				tempDirApi = tempDir(config['site_dir'], "assets/.doxy/", project_name)
 
 			# Check src changes -> run Doxygen
-			doxygenRun = DoxygenRun(self.config['doxygen-bin-path'], project_data.get('src-dirs'), tempDirApi, project_data.get('doxy-cfg', {}))
+			runPath = os.path.dirname(config.config_file_path) if config.config_file_path else None
+			doxygenRun = DoxygenRun(self.config['doxygen-bin-path'], project_data.get('src-dirs'), tempDirApi, project_data.get('doxy-cfg', {}), runPath)
 			if doxygenRun.checkAndRun():
 				log.info("  -> generating Doxygen files")
 			else:


### PR DESCRIPTION
When mkdocs is used with the -f flag, the run directory might not be the current one, and thus the src-dirs need to be resolved relative to the mkdocs.yml file given by the -f flag.

Also fixed an import that was used as a path typing by mistake