### PR TITLE
Add ruamel.yaml as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs
+ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'Funding': 'https://github.com/sponsors/jakubandrysek',
     },
 
-    install_requires=['mkdocs'],
+    install_requires=['mkdocs', 'ruamel.yaml'],
     extras_require={
         "dev": [
             "mkdocs-material==9.1.18",


### PR DESCRIPTION
Without ruamel.yaml installed, MkDoxy doesn't work.

File ".../MkDoxy/mkdoxy/utils.py", line 5, in <module>
    from ruamel.yaml import YAML
ModuleNotFoundError: No module named 'ruamel'