### PR TITLE
Replace `ruamel.yaml` with `PyYAML` and Cleanup Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ All notable changes to this project will be documented in this file.
     - Add support for [custom templates](https://github.com/JakubAndrysek/MkDoxy/pull/39)
 - **v1.0.6** - 2023-04-01
     - Add support disable plugin [using environment variable](#disabling-the-plugin)
+- **v1.1.6** - 2023-07-20
+  - Replace `ruamel.yaml` with `pyyaml`. [#73](https://github.com/JakubAndrysek/MkDoxy/pull/73)
+  - Add `isort` as dev dependency. [#73](https://github.com/JakubAndrysek/MkDoxy/pull/73)
+  - Sort and cleanup imports [#73](https://github.com/JakubAndrysek/MkDoxy/pull/73)

--- a/mkdoxy/DoxyTagParser.py
+++ b/mkdoxy/DoxyTagParser.py
@@ -1,5 +1,6 @@
 import re
 
+
 class DoxyTagParser:
 
     def __init__(

--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -1,8 +1,8 @@
 import hashlib
 import logging
-import tempfile
+
 from pathlib import Path, PurePath
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 from typing import Optional
 
 log: logging.Logger = logging.getLogger("mkdocs")

--- a/mkdoxy/finder.py
+++ b/mkdoxy/finder.py
@@ -1,7 +1,9 @@
+from typing import Dict
+
 from mkdoxy.constants import Kind
 from mkdoxy.doxygen import Doxygen
 from mkdoxy.utils import recursive_find, recursive_find_with_parent
-from typing import Dict
+
 
 class Finder:
 	def __init__(self, doxygen: Dict[str, Doxygen], debug: bool = False):

--- a/mkdoxy/generatorBase.py
+++ b/mkdoxy/generatorBase.py
@@ -3,14 +3,19 @@ import os
 import string
 from typing import Dict
 
-from jinja2 import Template, FileSystemLoader, Environment, ChoiceLoader
+from jinja2 import Template
 from jinja2.exceptions import TemplateError
 from mkdocs import exceptions
 
 import mkdoxy
 from mkdoxy.constants import Kind
-from mkdoxy.node import Node, DummyNode
-from mkdoxy.utils import parseTemplateFile, merge_two_dicts, recursive_find_with_parent, recursive_find
+from mkdoxy.node import DummyNode, Node
+from mkdoxy.utils import (
+    merge_two_dicts,
+    parseTemplateFile,
+    recursive_find,
+    recursive_find_with_parent,
+)
 
 log: logging.Logger = logging.getLogger("mkdocs")
 

--- a/mkdoxy/generatorSnippets.py
+++ b/mkdoxy/generatorSnippets.py
@@ -1,17 +1,13 @@
 import logging
 import pathlib
 import re
-import string
-from pprint import *
 
-from mkdocs.config import Config
+import yaml
 from mkdocs.structure import pages
+
 from mkdoxy.doxygen import Doxygen
-
-from mkdoxy.generatorBase import GeneratorBase
-from ruamel.yaml import YAML, YAMLError
-
 from mkdoxy.finder import Finder
+from mkdoxy.generatorBase import GeneratorBase
 from mkdoxy.node import Node
 
 log: logging.Logger = logging.getLogger("mkdocs")
@@ -112,9 +108,8 @@ class GeneratorSnippets:
 
 	def try_load_yaml(self, yaml_raw: str, project: str, snippet: str, config: dict) -> dict:
 		try:
-			yaml = YAML()
-			return yaml.load(yaml_raw)
-		except YAMLError as e:
+			return yaml.safe_load(yaml_raw)
+		except yaml.YAMLError as e:
 			log.error(f"YAML error in {project} project on page {self.page.url}")
 			self.doxyError(
 				project,

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -1,5 +1,6 @@
 from typing import List
 
+
 def escape(s: str) -> str:
 	ret = s.replace('*', '\\*')
 	ret = ret.replace('_', '\\_')

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element as Element
 
 from mkdoxy.cache import Cache
-from mkdoxy.constants import Kind, Visibility, OVERLOAD_OPERATORS
+from mkdoxy.constants import OVERLOAD_OPERATORS, Kind, Visibility
 from mkdoxy.markdown import escape
 from mkdoxy.property import Property
 from mkdoxy.utils import split_safe

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path, PurePath
 
 from mkdocs import exceptions
-from mkdocs.config import base, config_options, Config
+from mkdocs.config import Config, base, config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure import files, pages
 
@@ -19,7 +19,6 @@ from mkdoxy.doxyrun import DoxygenRun
 from mkdoxy.generatorAuto import GeneratorAuto
 from mkdoxy.generatorBase import GeneratorBase
 from mkdoxy.generatorSnippets import GeneratorSnippets
-from mkdoxy.utils import check_enabled_markdown_extensions
 from mkdoxy.xml_parser import XmlParser
 
 log: logging.Logger = logging.getLogger("mkdocs")

--- a/mkdoxy/utils.py
+++ b/mkdoxy/utils.py
@@ -1,8 +1,8 @@
 import logging
 import re
 
+import yaml
 from mkdocs.config import Config
-from ruamel.yaml import YAML
 
 log: logging.Logger = logging.getLogger("mkdocs")
 
@@ -73,10 +73,8 @@ def parseTemplateFile(templateFile: str):
 	if match:
 		template = match["template"]
 		meta = match["meta"]
-		yaml = YAML(typ='safe')
-		metaData = yaml.load(meta)
-		# yaml.dump(metaData, sys.stdout)
-		return template, metaData
+		metadata = yaml.safe_load(meta)
+		return template, metadata
 	return templateFile, {}
 
 

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -1,8 +1,25 @@
 from xml.etree.ElementTree import Element as Element
 
 from mkdoxy.cache import Cache
-from mkdoxy.markdown import Md, MdRenderer, MdParagraph, MdTable, Code, MdTableRow, MdCodeBlock, MdTableCell, \
-    MdHeader, MdImage, MdList, MdBlockQuote, MdLink, MdBold, MdItalic, Text, Br
+from mkdoxy.markdown import (
+    Br,
+    Code,
+    Md,
+    MdBlockQuote,
+    MdBold,
+    MdCodeBlock,
+    MdHeader,
+    MdImage,
+    MdItalic,
+    MdLink,
+    MdList,
+    MdParagraph,
+    MdRenderer,
+    MdTable,
+    MdTableCell,
+    MdTableRow,
+    Text,
+)
 from mkdoxy.utils import lookahead
 
 SIMPLE_SECTIONS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 mkdocs
-ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def requirements():
 # https://pypi.org/project/mkdoxy/
 setup(
     name='mkdoxy',
-    version='1.1.5',
+    version='1.1.6',
     description='MkDoxy → MkDocs + Doxygen = easy documentation generator with code snippets',
     long_description=readme(),
     long_description_content_type='text/markdown',
@@ -29,7 +29,7 @@ setup(
         'Funding': 'https://github.com/sponsors/jakubandrysek',
     },
 
-    install_requires=['mkdocs', 'ruamel.yaml'],
+    install_requires=['mkdocs'],
     extras_require={
         "dev": [
             "mkdocs-material==9.1.18",
@@ -38,6 +38,7 @@ setup(
             "mkdocs-open-in-new-tab~=1.0.2",
             "pathlib~=1.0.1",
             "path~=16.7.1",
+            "isort~=5.12.0"
             ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "dev": [
             "mkdocs-material==9.1.18",
             "Jinja2~=3.1.2",
-            "ruamel.yaml~=0.17.32",
             "mkdocs-open-in-new-tab~=1.0.2",
             "pathlib~=1.0.1",
             "path~=16.7.1",

--- a/tests-old/metaDataParse.py
+++ b/tests-old/metaDataParse.py
@@ -57,6 +57,6 @@ regex = r"(-{3}|\.{3})\n(?P<meta>([\S\s])*)\n(-{3}|\.{3})\n(?P<template>([\S\s])
 
 
 match = re.match(regex, text2, re.MULTILINE)
-meta = match.group("meta")
+meta = match["meta"]
 config = yaml.safe_load(meta)
 yaml.dump(config, sys.stdout)

--- a/tests-old/metaDataParse.py
+++ b/tests-old/metaDataParse.py
@@ -59,4 +59,4 @@ regex = r"(-{3}|\.{3})\n(?P<meta>([\S\s])*)\n(-{3}|\.{3})\n(?P<template>([\S\s])
 match = re.match(regex, text2, re.MULTILINE)
 meta = match["meta"]
 config = yaml.safe_load(meta)
-yaml.dump(config, sys.stdout)
+yaml.safe_dump(config, sys.stdout)

--- a/tests-old/metaDataParse.py
+++ b/tests-old/metaDataParse.py
@@ -4,7 +4,8 @@ from markdown import preprocessors, util
 from markdown.extensions import meta
 import re
 from pprint import *
-from ruamel.yaml import YAML
+import yaml
+
 
 text = """\
 ---
@@ -57,6 +58,5 @@ regex = r"(-{3}|\.{3})\n(?P<meta>([\S\s])*)\n(-{3}|\.{3})\n(?P<template>([\S\s])
 
 match = re.match(regex, text2, re.MULTILINE)
 meta = match.group("meta")
-yaml = YAML(typ='safe')
-config = yaml.load(meta)
+config = yaml.safe_load(meta)
 yaml.dump(config, sys.stdout)

--- a/tests-old/parseMdTags.py
+++ b/tests-old/parseMdTags.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 		if yamlRaw:
 			try:
 				config = yaml.safe_load(yamlRaw)
-				yaml.dump(config, sys.stdout)
+				yaml.safe_dump(config, sys.stdout)
 			except yaml.YAMLError as e:
 				print(e)
 		print()

--- a/tests-old/parseMdTags.py
+++ b/tests-old/parseMdTags.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from pathlib import Path
-from ruamel.yaml import YAML
+import yaml
 
 
 def readFile(filename: str) -> str:
@@ -28,8 +28,7 @@ if __name__ == '__main__':
 		yamlRaw = match.group('yaml')
 		if yamlRaw:
 			try:
-				yaml = YAML()
-				config = yaml.load(yamlRaw)
+				config = yaml.safe_load(yamlRaw)
 				yaml.dump(config, sys.stdout)
 			except yaml.YAMLError as e:
 				print(e)


### PR DESCRIPTION
Closes #70.

1. Replaced `ruamel.yaml` with `pyyaml` since it comes with `MkDocs`.
2. Added and applied `isort` to sort imports
3. Cleaned up unused imports

I tested it with my documentation, seems to work exactly the same. However not sure how to run your tests.

May I suggest (for the future):
1. Migrate to `pyproject.toml` from `setup.py`
2. Writing a contributor guide
3. Implement minimal linting (black + flake8)
4. Automated tests