### PR TITLE
fix: add missing package visibility

### DIFF
--- a/mkdoxy/constants.py
+++ b/mkdoxy/constants.py
@@ -165,5 +165,6 @@ class Kind(Enum):
 
 class Visibility(Enum):
     PUBLIC = "public"
+    PACKAGE = "package"
     PROTECTED = "protected"
     PRIVATE = "private"


### PR DESCRIPTION
Hello  today i had following issue, that doxygen create for   c# code likes this:

```cs
internal class Foo {
 void Do() {
 }
}
```
 xml output like:

```xml
...
<compounddef id="classFoo" kind="class" language="C#" prot="package">
..
```
and the value "package" in the `prot` element cause an exception during build process:
```
INFO    -  Start plugin MkDoxy
INFO    -  -> Start project 'PublicApiRef'
INFO    -    -> generating Doxygen files
Traceback (most recent call last):
  File ".venv/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File ".venv/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File ".venv/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File ".venv/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File ".venv/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File ".venv/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File ".venv/lib/python3.9/site-packages/mkdocs/__main__.py", line 286, in build_command
    build.build(cfg, dirty=not clean)
  File ".venv/lib/python3.9/site-packages/mkdocs/commands/build.py", line 304, in build
    files = config.plugins.on_files(files, config=config)
  File ".venv/lib/python3.9/site-packages/mkdocs/plugins.py", line 533, in on_files
    return self.run_event('files', files, config=config)
  File ".venv/lib/python3.9/site-packages/mkdocs/plugins.py", line 507, in run_event
    result = method(item, **kwargs)
  File ".venv/lib/python3.9/site-packages/mkdoxy/plugin.py", line 126, in on_files
    self.doxygen[project_name] = Doxygen(doxygenRun.getOutputFolder(), parser=parser, cache=cache)
  File ".venv/lib/python3.9/site-packages/mkdoxy/doxygen.py", line 35, in __init__
    node = Node(
  File ".venv/lib/python3.9/site-packages/mkdoxy/node.py", line 53, in __init__
    self._check_for_children()
  File ".venv/lib/python3.9/site-packages/mkdoxy/node.py", line 222, in _check_for_children
    child = Node(None, memberdef, self._cache, self._parser, self)
  File ".venv/lib/python3.9/site-packages/mkdoxy/node.py", line 66, in __init__
    self._check_attrs()
  File ".venv/lib/python3.9/site-packages/mkdoxy/node.py", line 241, in _check_attrs
    self._visibility = Visibility(prot) if prot is not None else Visibility.PUBLIC
  File "/usr/local/lib/python3.9/enum.py", line 384, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.9/enum.py", line 702, in __new__
    raise ve_exc
ValueError: 'package' is not a valid Visibility
```


by adding the `package` value to the `Visibility` enum,  the exception did no longer appears.