### PR TITLE
Correctly display inline code blocks-2

### DIFF
--- a/mkdoxy/filters.py
+++ b/mkdoxy/filters.py
@@ -1,0 +1,22 @@
+import re
+
+
+PLAIN_CODE_BLOCK = re.compile(r'```(\n.*?\n)```', re.DOTALL)
+
+
+def use_code_language(value, code_language: str|None):
+    """! Jinja2 filter to apply a code language to all plain code blocks
+    @details
+    @param value: the value to apply the filter to.
+    @param code_language (str|None): the code language to apply.
+    @return: The filtered value.
+    """
+    if not code_language:
+        return value
+
+    return re.sub(
+        PLAIN_CODE_BLOCK,
+        lambda m: f'```{code_language}{m[1]}```',
+        str(value)
+    )
+    

--- a/mkdoxy/filters.py
+++ b/mkdoxy/filters.py
@@ -1,10 +1,10 @@
 import re
+from typing import Optional
+
+PLAIN_CODE_BLOCK = re.compile(r"```(\n.*?\n)```", re.DOTALL)
 
 
-PLAIN_CODE_BLOCK = re.compile(r'```(\n.*?\n)```', re.DOTALL)
-
-
-def use_code_language(value, code_language: str|None):
+def use_code_language(value, code_language: Optional[str]):
     """! Jinja2 filter to apply a code language to all plain code blocks
     @details
     @param value: the value to apply the filter to.
@@ -14,9 +14,4 @@ def use_code_language(value, code_language: str|None):
     if not code_language:
         return value
 
-    return re.sub(
-        PLAIN_CODE_BLOCK,
-        lambda m: f'```{code_language}{m[1]}```',
-        str(value)
-    )
-    
+    return re.sub(PLAIN_CODE_BLOCK, lambda m: f"```{code_language}{m[1]}```", str(value))

--- a/mkdoxy/generatorBase.py
+++ b/mkdoxy/generatorBase.py
@@ -40,7 +40,7 @@ class GeneratorBase:
         self.metaData: Dict[str, list[str]] = {}
 
         environment = Environment(loader=BaseLoader())
-        environment.filters['use_code_language'] = use_code_language
+        environment.filters["use_code_language"] = use_code_language
         # code from https://github.com/daizutabi/mkapi/blob/master/mkapi/core/renderer.py#L29-L38
         path = os.path.join(os.path.dirname(mkdoxy.__file__), "templates")
         for fileName in os.listdir(path):

--- a/mkdoxy/generatorBase.py
+++ b/mkdoxy/generatorBase.py
@@ -3,12 +3,13 @@ import os
 import string
 from typing import Dict
 
-from jinja2 import Template
+from jinja2 import BaseLoader, Environment, Template
 from jinja2.exceptions import TemplateError
 from mkdocs import exceptions
 
 import mkdoxy
 from mkdoxy.constants import Kind
+from mkdoxy.filters import use_code_language
 from mkdoxy.node import DummyNode, Node
 from mkdoxy.utils import (
     merge_two_dicts,
@@ -38,6 +39,8 @@ class GeneratorBase:
         self.templates: Dict[str, Template] = {}
         self.metaData: Dict[str, list[str]] = {}
 
+        environment = Environment(loader=BaseLoader())
+        environment.filters['use_code_language'] = use_code_language
         # code from https://github.com/daizutabi/mkapi/blob/master/mkapi/core/renderer.py#L29-L38
         path = os.path.join(os.path.dirname(mkdoxy.__file__), "templates")
         for fileName in os.listdir(path):
@@ -46,7 +49,7 @@ class GeneratorBase:
                 with open(filePath, "r") as file:
                     name = os.path.splitext(fileName)[0]
                     fileTemplate, metaData = parseTemplateFile(file.read())
-                    self.templates[name] = Template(fileTemplate)
+                    self.templates[name] = environment.from_string(fileTemplate)
                     self.metaData[name] = metaData
             else:
                 log.error(f"Trying to load unsupported file '{filePath}'. Supported file ends with '.jinja2'.")

--- a/mkdoxy/generatorSnippets.py
+++ b/mkdoxy/generatorSnippets.py
@@ -225,6 +225,9 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         node = self.finder.doxyCode(project, config.get("file"))
+        if node is None:
+            return self.doxyNodeIsNone(project, config, snippet)
+
         if isinstance(node, Node):
             progCode = self.codeStrip(
                 node.programlisting,
@@ -268,6 +271,9 @@ class GeneratorSnippets:
             return errorMsg
 
         node = self.finder.doxyFunction(project, config.get("name"))
+        if node is None:
+            return self.doxyNodeIsNone(project, config, snippet)
+
         if isinstance(node, Node):
             self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].function(node, config)
@@ -288,6 +294,9 @@ class GeneratorSnippets:
             return errorMsg
 
         node = self.finder.doxyClass(project, config.get("name"))
+        if node is None:
+            return self.doxyNodeIsNone(project, config, snippet)
+
         if isinstance(node, Node):
             self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].member(node, config)
@@ -308,6 +317,9 @@ class GeneratorSnippets:
             return errorMsg
 
         node = self.finder.doxyClassMethod(project, config.get("name"), config.get("method"))
+        if node is None:
+            return self.doxyNodeIsNone(project, config, snippet)
+
         if isinstance(node, Node):
             self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].function(node, config)
@@ -362,6 +374,16 @@ class GeneratorSnippets:
         self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].fileindex(nodes, config)
 
+
+    def doxyNodeIsNone(self, project: str, config: dict, snippet: str) -> str:
+        return self.doxyError(
+            project,
+            config,
+            "Node is None",
+            "Node is None",
+            "yaml",
+            snippet,
+        )
 
 ### Create documentation generator callbacks END
 

--- a/mkdoxy/generatorSnippets.py
+++ b/mkdoxy/generatorSnippets.py
@@ -374,7 +374,6 @@ class GeneratorSnippets:
         self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].fileindex(nodes, config)
 
-
     def doxyNodeIsNone(self, project: str, config: dict, snippet: str) -> str:
         return self.doxyError(
             project,
@@ -384,6 +383,7 @@ class GeneratorSnippets:
             "yaml",
             snippet,
         )
+
 
 ### Create documentation generator callbacks END
 

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -100,9 +100,11 @@ class MdCodeBlock:
         self.lines.append(line)
 
     def render(self, f: MdRenderer, indent: str):
+        f.write('```\n')
         for line in self.lines:
             f.write(line)
             f.write("\n")
+        f.write('```\n')
 
 
 class MdBlockQuote(Md):

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -100,11 +100,11 @@ class MdCodeBlock:
         self.lines.append(line)
 
     def render(self, f: MdRenderer, indent: str):
-        f.write('```\n')
+        f.write("```\n")
         for line in self.lines:
             f.write(line)
             f.write("\n")
-        f.write('```\n')
+        f.write("```\n")
 
 
 class MdBlockQuote(Md):

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -687,7 +687,7 @@ class Node:
 
         else:
             code.append(self._definition.plain())
-        return "\n".join(['```', *code, '```'])
+        return "\n".join(["```", *code, "```"])
 
     @property
     def has_base_classes(self) -> bool:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -687,7 +687,7 @@ class Node:
 
         else:
             code.append(self._definition.plain())
-        return "\n".join(code)
+        return "\n".join(['```', *code, '```'])
 
     @property
     def has_base_classes(self) -> bool:

--- a/mkdoxy/templates/example.jinja2
+++ b/mkdoxy/templates/example.jinja2
@@ -1,9 +1,8 @@
 {% filter indent(config.get('indent_level', 0), True) %}
 # {{node.title}}
 
-{{node.details}}
+{{node.details | use_code_language(node.code_language)}}
 
-```{{ node.code_language }}
-{{node.programlisting}}
-```
+{{node.programlisting | use_code_language(node.code_language)}}
+
 {% endfilter %}

--- a/mkdoxy/templates/memDef.jinja2
+++ b/mkdoxy/templates/memDef.jinja2
@@ -16,14 +16,12 @@ url_source: True
 {%- endif -%}
 {%- endif -%}
 
-```{{node.code_language}}
-{{node.codeblock}}
-```
+{{node.codeblock | use_code_language(node.code_language)}}
 
 
 {% if configMemDef.get('details') -%}
 {% if node.has_details -%}
-{{node.details}}
+{{node.details | use_code_language(node.code_language)}}
 {%- endif -%}
 {%- endif -%}
 

--- a/mkdoxy/templates/member.jinja2
+++ b/mkdoxy/templates/member.jinja2
@@ -70,7 +70,7 @@ Inherited by the following classes:
 {%- if node.has_details %}
 # Detailed Description
 
-{{node.details}}
+{{node.details | use_code_language(node.code_language)}}
 {%- endif %}
 
 {%- for visibility in ['public', 'protected'] -%}

--- a/mkdoxy/templates/page.jinja2
+++ b/mkdoxy/templates/page.jinja2
@@ -3,7 +3,7 @@
 {% if node.title %}{{node.title}}{% else %}# Related Pages{% endif %}
 
 {% if node.details %}
-{{node.details}}
+{{node.details | use_code_language(node.code_language)}}
 {% else %}
 No related pages found.
 {% endif %}

--- a/mkdoxy/templates/programlisting.jinja2
+++ b/mkdoxy/templates/programlisting.jinja2
@@ -13,8 +13,6 @@ breadcrumbs: False
 
 [Go to the documentation of this file]({{node.url}})
 
-```{{ node.code_language }}
-{{node.programlisting}}
-```
+{{node.programlisting | use_code_language(node.code_language)}}
 
 {% endfilter %}


### PR DESCRIPTION
Fixes the issue where inline code blocks (i.e. in a `details` section) don't display correctly.

This is done by first outputting all code sections as plain code blocks (using ` ``` ` without a language) and then applying a filter in the jinja2 templates that adds the active language to any plain code blocks.

fixes #79

PR by @r-braun - https://github.com/JakubAndrysek/MkDoxy/pull/96