### PR TITLE
Fix executable not found when the current working directory (cwd) is set to config file path

### DIFF
--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -22,7 +22,6 @@ class DoxygenRun:
         tempDoxyFolder: str,
         doxyCfgNew,
         doxyConfigFile: Optional[str] = None,
-        runPath: Optional[str] = None,
     ):
         """! Constructor.
         Default Doxygen config options:
@@ -58,7 +57,6 @@ class DoxygenRun:
         self.doxyConfigFile: Optional[str] = doxyConfigFile
         self.hashFileName: str = "hashChanges.yaml"
         self.hashFilePath: PurePath = PurePath.joinpath(Path(self.tempDoxyFolder), Path(self.hashFileName))
-        self.runPath: Optional[str] = runPath
         self.doxyCfg: dict = self.setDoxyCfg(doxyCfgNew)
 
     def setDoxyCfg(self, doxyCfgNew: dict) -> dict:
@@ -224,7 +222,6 @@ class DoxygenRun:
             stdout=PIPE,
             stdin=PIPE,
             stderr=PIPE,
-            cwd=self.runPath,
         )
         (doxyBuilder.communicate(self.dox_dict2str(self.doxyCfg).encode("utf-8"))[0].decode().strip())
         # log.info(self.destinationDir)

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -5,7 +5,6 @@ MkDoxy is a MkDocs plugin for generating documentation from Doxygen XML files.
 """
 
 import logging
-import os
 from pathlib import Path, PurePath
 
 from mkdocs import exceptions

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -114,14 +114,12 @@ class MkDoxy(BasePlugin):
                 tempDirApi = tempDir(config["site_dir"], "assets/.doxy/", project_name)
 
             # Check src changes -> run Doxygen
-            runPath = os.path.dirname(config.config_file_path) if config.config_file_path else None
             doxygenRun = DoxygenRun(
                 self.config["doxygen-bin-path"],
                 project_data.get("src-dirs"),
                 tempDirApi,
                 project_data.get("doxy-cfg", {}),
                 project_data.get("doxy-cfg-file", ""),
-                runPath,
             )
             if doxygenRun.checkAndRun():
                 log.info("  -> generating Doxygen files")


### PR DESCRIPTION
This commit resolves the issue where `mkdocs build --config-file mkdocs.yml` fails due to the process not properly locating the executable when the current working directory (cwd) is set to a specific path. Fix #75.