### PR TITLE
fix: use absolute links for inherited items

### DIFF
--- a/mkdoxy/doxygen.py
+++ b/mkdoxy/doxygen.py
@@ -5,6 +5,7 @@ from xml.etree import ElementTree
 from mkdoxy.cache import Cache
 from mkdoxy.constants import Kind, Visibility
 from mkdoxy.node import Node
+from mkdoxy.project import ProjectContext
 from mkdoxy.xml_parser import XmlParser
 
 log: logging.Logger = logging.getLogger("mkdocs")
@@ -19,13 +20,13 @@ class Doxygen:
         xml = ElementTree.parse(path_xml).getroot()
 
         self.parser = parser
-        self.cache = cache
+        self.ctx = ProjectContext(cache)
 
-        self.root = Node("root", None, self.cache, self.parser, None)
-        self.groups = Node("root", None, self.cache, self.parser, None)
-        self.files = Node("root", None, self.cache, self.parser, None)
-        self.pages = Node("root", None, self.cache, self.parser, None)
-        self.examples = Node("root", None, self.cache, self.parser, None)
+        self.root = Node("root", None, self.ctx, self.parser, None)
+        self.groups = Node("root", None, self.ctx, self.parser, None)
+        self.files = Node("root", None, self.ctx, self.parser, None)
+        self.pages = Node("root", None, self.ctx, self.parser, None)
+        self.examples = Node("root", None, self.ctx, self.parser, None)
 
         for compound in xml.findall("compound"):
             kind = Kind.from_str(compound.get("kind"))
@@ -34,7 +35,7 @@ class Doxygen:
                 node = Node(
                     os.path.join(index_path, f"{refid}.xml"),
                     None,
-                    self.cache,
+                    self.ctx,
                     self.parser,
                     self.root,
                 )
@@ -44,7 +45,7 @@ class Doxygen:
                 node = Node(
                     os.path.join(index_path, f"{refid}.xml"),
                     None,
-                    self.cache,
+                    self.ctx,
                     self.parser,
                     self.root,
                 )
@@ -54,7 +55,7 @@ class Doxygen:
                 node = Node(
                     os.path.join(index_path, f"{refid}.xml"),
                     None,
-                    self.cache,
+                    self.ctx,
                     self.parser,
                     self.root,
                 )
@@ -64,7 +65,7 @@ class Doxygen:
                 node = Node(
                     os.path.join(index_path, f"{refid}.xml"),
                     None,
-                    self.cache,
+                    self.ctx,
                     self.parser,
                     self.root,
                 )
@@ -74,7 +75,7 @@ class Doxygen:
                 node = Node(
                     os.path.join(index_path, f"{refid}.xml"),
                     None,
-                    self.cache,
+                    self.ctx,
                     self.parser,
                     self.root,
                 )

--- a/mkdoxy/generatorSnippets.py
+++ b/mkdoxy/generatorSnippets.py
@@ -152,7 +152,7 @@ class GeneratorSnippets:
             project,
             config,
             f"Incorrect argument: {argument}" if argument else f"Add argument to snippet: {project}",
-            f"Argument have to be based on this diagram → **:::doxy.{project}.<argument\>**",
+            f"Argument have to be based on this diagram → **:::doxy.{project}.<argument\\>**",
             "A list of available arguments:",
             "\n".join(self.doxy_arguments.keys()),
             "yaml",
@@ -162,14 +162,12 @@ class GeneratorSnippets:
     def replace_markdown(self, start: int, end: int, replacement: str):
         self.markdown = self.markdown[:start] + replacement + "\n" + self.markdown[end:]
 
-    def _recurs_setLinkPrefixNode(self, node: Node, linkPrefix: str):
-        node.setLinkPrefix(linkPrefix)
-        if node.kind.is_parent():
-            self._recurs_setLinkPrefixNodes(node.children, linkPrefix)
+    def _setLinkPrefixNode(self, node: Node, linkPrefix: str):
+        node.project.linkPrefix = linkPrefix
 
-    def _recurs_setLinkPrefixNodes(self, nodes: [Node], linkPrefix: str):
-        for node in nodes:
-            self._recurs_setLinkPrefixNode(node, linkPrefix)
+    def _setLinkPrefixNodes(self, nodes: list[Node], linkPrefix: str):
+        if nodes:
+            nodes[0].project.linkPrefix = linkPrefix
 
     def is_project_exist(self, project: str):
         return project in self.projects
@@ -249,7 +247,7 @@ class GeneratorSnippets:
                     f"{snippet}",
                     "yaml",
                 )
-            self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
+            self._setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].code(node, config, progCode)
         return self.doxyError(
             project,
@@ -281,7 +279,7 @@ class GeneratorSnippets:
             return self.doxyNodeIsNone(project, config, snippet)
 
         if isinstance(node, Node):
-            self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
+            self._setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].function(node, config)
         return self.doxyError(
             project,
@@ -304,7 +302,7 @@ class GeneratorSnippets:
             return self.doxyNodeIsNone(project, config, snippet)
 
         if isinstance(node, Node):
-            self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
+            self._setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].member(node, config)
         return self.doxyError(
             project,
@@ -327,7 +325,7 @@ class GeneratorSnippets:
             return self.doxyNodeIsNone(project, config, snippet)
 
         if isinstance(node, Node):
-            self._recurs_setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
+            self._setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
             return self.generatorBase[project].function(node, config)
         return self.doxyError(
             project,
@@ -345,7 +343,7 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         nodes = self.doxygen[project].root.children
-        self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].annotated(nodes, config)
 
     def doxyClassIndex(self, snippet, project: str, config):
@@ -353,7 +351,7 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         nodes = self.doxygen[project].root.children
-        self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].classes(nodes, config)
 
     def doxyClassHierarchy(self, snippet, project: str, config):
@@ -361,7 +359,7 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         nodes = self.doxygen[project].root.children
-        self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].hierarchy(nodes, config)
 
     def doxyNamespaceList(self, snippet, project: str, config):
@@ -369,7 +367,7 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         nodes = self.doxygen[project].root.children
-        self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].namespaces(nodes, config)
 
     def doxyFileList(self, snippet, project: str, config):
@@ -377,7 +375,7 @@ class GeneratorSnippets:
         if errorMsg:
             return errorMsg
         nodes = self.doxygen[project].files.children
-        self._recurs_setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].fileindex(nodes, config)
 
     def doxyNodeIsNone(self, project: str, config: dict, snippet: str) -> str:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -3,9 +3,9 @@ import os
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element as Element
 
-from mkdoxy.cache import Cache
 from mkdoxy.constants import OVERLOAD_OPERATORS, Kind, Visibility
 from mkdoxy.markdown import escape
+from mkdoxy.project import ProjectContext
 from mkdoxy.property import Property
 from mkdoxy.utils import split_safe
 from mkdoxy.xml_parser import XmlParser
@@ -18,18 +18,18 @@ class Node:
         self,
         xml_file: str,
         xml: Element,
-        cache: Cache,
+        project: ProjectContext,
         parser: XmlParser,
         parent: "Node",
         refid: str = None,
         debug: bool = False,
     ):
         self._children: ["Node"] = []
-        self._cache: Cache = cache
+        self._cache = project.cache
         self._parser: XmlParser = parser
         self._parent = parent
         self.debug = debug
-        self.linkPrefix = ""
+        self.project = project
 
         if xml_file == "root":
             self._refid = "root"
@@ -91,9 +91,6 @@ class Node:
     def __repr__(self):
         return f"Node: {self.name} refid: {self._refid}"
 
-    def setLinkPrefix(self, linkPrefix: str):
-        self.linkPrefix = linkPrefix
-
     def add_child(self, child: "Node"):
         self._children.append(child)
 
@@ -113,7 +110,7 @@ class Node:
             child = Node(
                 os.path.join(self._dirname, f"{refid}.xml"),
                 None,
-                self._cache,
+                self.project,
                 self._parser,
                 self,
             )
@@ -138,7 +135,7 @@ class Node:
                 child = Node(
                     os.path.join(self._dirname, f"{refid}.xml"),
                     None,
-                    self._cache,
+                    self.project,
                     self._parser,
                     self,
                 )
@@ -146,7 +143,7 @@ class Node:
                 child = Node(
                     os.path.join(self._dirname, f"{refid}.xml"),
                     Element("compounddef"),
-                    self._cache,
+                    self.project,
                     self._parser,
                     self,
                     refid=refid,
@@ -168,7 +165,7 @@ class Node:
             child = Node(
                 os.path.join(self._dirname, f"{refid}.xml"),
                 None,
-                self._cache,
+                self.project,
                 self._parser,
                 self,
             )
@@ -188,7 +185,7 @@ class Node:
             child = Node(
                 os.path.join(self._dirname, f"{refid}.xml"),
                 None,
-                self._cache,
+                self.project,
                 self._parser,
                 self,
             )
@@ -209,7 +206,7 @@ class Node:
             child = Node(
                 os.path.join(self._dirname, f"{refid}.xml"),
                 None,
-                self._cache,
+                self.project,
                 self._parser,
                 self,
             )
@@ -228,7 +225,7 @@ class Node:
                             continue
                         except Exception:
                             pass
-                    child = Node(None, memberdef, self._cache, self._parser, self)
+                    child = Node(None, memberdef, self.project, self._parser, self)
                     self.add_child(child)
 
         # for detaileddescription in self._xml.findall('detaileddescription'):
@@ -477,14 +474,14 @@ class Node:
     @property
     def url(self) -> str:
         if self.is_parent or self.is_group or self.is_file or self.is_dir or self.is_page:
-            return self.linkPrefix + self._refid + ".md"
+            return self.project.linkPrefix + self._refid + ".md"
         else:
             return f"{self._parent.url}#{self.anchor}"
 
     @property
     def base_url(self) -> str:
         def prefix(page: str):
-            return self.linkPrefix + page
+            return self.project.linkPrefix + page
 
         if self.is_group:
             return prefix("modules.md")
@@ -509,13 +506,13 @@ class Node:
     @property
     def url_source(self) -> str:
         if self.is_parent or self.is_group or self.is_file or self.is_dir:
-            return self.linkPrefix + self._refid + "_source.md"
+            return self.project.linkPrefix + self._refid + "_source.md"
         else:
-            return self.linkPrefix + self._refid + ".md"
+            return self.project.linkPrefix + self._refid + ".md"
 
     @property
     def filename(self) -> str:
-        return self.linkPrefix + self._refid + ".md"
+        return self.project.linkPrefix + self._refid + ".md"
 
     @property
     def root(self) -> "Node":

--- a/mkdoxy/project.py
+++ b/mkdoxy/project.py
@@ -1,0 +1,7 @@
+from mkdoxy.cache import Cache
+
+
+class ProjectContext:
+    def __init__(self, cache: Cache) -> None:
+        self.cache = cache
+        self.linkPrefix: str = ""

--- a/mkdoxy/templates/memTab.jinja2
+++ b/mkdoxy/templates/memTab.jinja2
@@ -24,7 +24,7 @@ See [{{node.name_long}}]({{node.url}})
 {%- elif member.is_class or member.is_interface or member.is_struct -%}
 | {{member.kind.value}} | [**{{member.name_long if node.is_group else member.name_short}}**]({{member.url}}) {{member.suffix}}<br>{{member.brief}} |
 {%- elif member.is_enum or member.is_function or member.is_variable or member.is_union or member.is_typedef -%}
-| {{member.prefix}} {{member.type}} | [**{{member.name_long if node.is_group else member.name_short}}**](#{{member.anchor}}) {{member.params}} {{member.suffix}}<br>{{member.brief}} |
+| {{member.prefix}} {{member.type}} | [**{{member.name_long if node.is_group else member.name_short}}**]({%- if parent %}{{member.url}}{%- else -%}#{{member.anchor}}{%- endif -%}) {{member.params}} {{member.suffix}}<br>{{member.brief}} |
 {%- else -%}
 | {{member.prefix}} {{member.type}} | [**{{member.name_long if node.is_group else member.name_short}}**]({{member.url}}) {{member.params}} {{member.suffix}}<br>{{member.brief}} |
 {%- endif %}


### PR DESCRIPTION
When compiling the documentation in this repository, you get a bunch of warnings about unknown links:

```
INFO    -  Doc file 'snippets/classes.md' contains a link '#typedef-parents', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-animal-13', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-animal-23', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-animal-33', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-get_name', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-get_num_of_eyes', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-get_num_of_limbs', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-get_parents', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-has_tail', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-operator-bool', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-some_inline_member_function', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-animal', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-find_child_by_name', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#function-find_parent_by_name', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#variable-father', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#variable-mother', but there is no such anchor on this page.
INFO    -  Doc file 'snippets/classes.md' contains a link '#variable-name', but there is no such anchor on this page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_block_quote.md' contains a link '#variable-children', but there is no such anchor on   
           this page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_block_quote.md' contains a link '#function-append', but there is no such anchor on this           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_block_quote.md' contains a link '#function-extend', but there is no such anchor on this           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_bold.md' contains a link '#variable-children', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_bold.md' contains a link '#function-append', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_bold.md' contains a link '#function-extend', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_header.md' contains a link '#variable-children', but there is no such anchor on this   
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_header.md' contains a link '#function-append', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_header.md' contains a link '#function-extend', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_hint.md' contains a link '#variable-children', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_hint.md' contains a link '#function-append', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_hint.md' contains a link '#function-extend', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_italic.md' contains a link '#variable-children', but there is no such anchor on this   
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_italic.md' contains a link '#function-append', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_italic.md' contains a link '#function-extend', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_link.md' contains a link '#variable-children', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_link.md' contains a link '#function-append', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_link.md' contains a link '#function-extend', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_list.md' contains a link '#variable-children', but there is no such anchor on this     
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_list.md' contains a link '#function-append', but there is no such anchor on this page. 
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_list.md' contains a link '#function-extend', but there is no such anchor on this page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_paragraph.md' contains a link '#variable-children', but there is no such anchor on this           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_paragraph.md' contains a link '#function-append', but there is no such anchor on this  
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_paragraph.md' contains a link '#function-extend', but there is no such anchor on this  
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table.md' contains a link '#variable-children', but there is no such anchor on this    
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table.md' contains a link '#function-append', but there is no such anchor on this page.INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table.md' contains a link '#function-extend', but there is no such anchor on this page.INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_cell.md' contains a link '#variable-children', but there is no such anchor on    
           this page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_cell.md' contains a link '#function-append', but there is no such anchor on this 
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_cell.md' contains a link '#function-extend', but there is no such anchor on this 
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_row.md' contains a link '#variable-children', but there is no such anchor on this           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_row.md' contains a link '#function-append', but there is no such anchor on this  
           page.
INFO    -  Doc file 'mkdoxyApi/classmkdoxy_1_1markdown_1_1_md_table_row.md' contains a link '#function-extend', but there is no such anchor on this  
           page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#typedef-parents', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-animal-13', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-animal-23', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-animal-33', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-get_name', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-get_num_of_eyes', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-get_num_of_limbs', but there is no such anchor on this page.        
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-get_parents', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-has_tail', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-operator-bool', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-some_inline_member_function', but there is no such anchor on this   
           page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-animal', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-find_child_by_name', but there is no such anchor on this page.      
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#function-find_parent_by_name', but there is no such anchor on this page.     
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#variable-father', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#variable-mother', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_bird.md' contains a link '#variable-name', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#typedef-parents', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-bird-13', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-bird-23', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-bird-33', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-make_sound', but there is no such anchor on this page.      
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-move', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-bird', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-animal-13', but there is no such anchor on this page.       
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-animal-23', but there is no such anchor on this page.       
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-animal-33', but there is no such anchor on this page.       
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-get_name', but there is no such anchor on this page.        
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-get_num_of_eyes', but there is no such anchor on this page. 
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-get_num_of_limbs', but there is no such anchor on this page.INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-get_parents', but there is no such anchor on this page.     
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-has_tail', but there is no such anchor on this page.        
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-operator-bool', but there is no such anchor on this page.   
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-some_inline_member_function', but there is no such anchor on           this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-animal', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-find_child_by_name', but there is no such anchor on this    
           page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#function-find_parent_by_name', but there is no such anchor on this   
           page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#variable-father', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#variable-mother', but there is no such anchor on this page.
INFO    -  Doc file 'animal/classexample_1_1_special_bird.md' contains a link '#variable-name', but there is no such anchor on this page.
```

This PR fixes this by using absolute links when rendering inherited items or items embedded on other pages.

---

Btw, is there a way to see the generated markdown files? Or rather, where can I see them?