### PR TITLE
add api-path to project configuration

### DIFF
--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -5,6 +5,7 @@ MkDoxy is a MkDocs plugin for generating documentation from Doxygen XML files.
 """
 
 import logging
+import os
 from pathlib import Path, PurePath
 
 from mkdocs import exceptions
@@ -47,6 +48,7 @@ class MkDoxy(BasePlugin):
         ("full-doc", config_options.Type(bool, default=True)),
         ("debug", config_options.Type(bool, default=False)),
         # ('ignore-errors', config_options.Type(bool, default=False)),
+        ("api-path", config_options.Type(str, default=".")),
         ("doxy-cfg", config_options.Type(dict, default={}, required=False)),
         ("doxy-cfg-file", config_options.Type(str, default="", required=False)),
         ("template-dir", config_options.Type(str, default="", required=False)),
@@ -148,7 +150,9 @@ class MkDoxy(BasePlugin):
                     generatorBase=self.generatorBase[project_name],
                     tempDoxyDir=tempDirApi,
                     siteDir=config["site_dir"],
-                    apiPath=project_name,
+                    apiPath=os.path.join(
+                        project_data.get("api-path", "."), project_data.get("src-dirs")
+                    ),
                     doxygen=self.doxygen[project_name],
                     useDirectoryUrls=config["use_directory_urls"],
                 )

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -5,7 +5,6 @@ MkDoxy is a MkDocs plugin for generating documentation from Doxygen XML files.
 """
 
 import logging
-import os
 from pathlib import Path, PurePath
 
 from mkdocs import exceptions

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -150,9 +150,7 @@ class MkDoxy(BasePlugin):
                     generatorBase=self.generatorBase[project_name],
                     tempDoxyDir=tempDirApi,
                     siteDir=config["site_dir"],
-                    apiPath=os.path.join(
-                        project_data.get("api-path", "."), project_data.get("src-dirs")
-                    ),
+                    apiPath = project_data.get("api-path", project_name),
                     doxygen=self.doxygen[project_name],
                     useDirectoryUrls=config["use_directory_urls"],
                 )

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -150,7 +150,7 @@ class MkDoxy(BasePlugin):
                     generatorBase=self.generatorBase[project_name],
                     tempDoxyDir=tempDirApi,
                     siteDir=config["site_dir"],
-                    apiPath = project_data.get("api-path", project_name),
+                    apiPath=project_data.get("api-path", project_name),
                     doxygen=self.doxygen[project_name],
                     useDirectoryUrls=config["use_directory_urls"],
                 )


### PR DESCRIPTION
First, thanks for this very helpful MkDocs plugin!

We have been using it for including our C++ code documentation which has been working well but is missing a useful feature. We generally put auto-generated code documentation in a sub-path of our main documentation to keep it organized, but MkDoxy currently always uses the project name as the output path.

To enable customizing the output path I made `api-path` a MkDoxy configurable setting.

I am also using the `src-dirs` as part of the generated API path but that could be removed. Some other options that could work is instead of:

```python
apiPath = os.path.join(
    project_data.get("api-path", "."), project_data.get("src-dirs")
)
```

are either:

```python
apiPath = os.path.join(project_data.get("api-path", "."), project_name)
```

or:

```python
apiPath = project_data.get("api-path", project_name)
```

and assume the user will put the full path for each project in the `api-path` configuration setting if they want to override the default.

Any of these would work for us. Is there any interest in merging this feature?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new 'api-path' configuration setting to the MkDoxy plugin, enabling users to customize the output path for auto-generated code documentation. The API path generation logic has been enhanced to incorporate this new setting along with 'src-dirs' for improved documentation organization.

- **New Features**:
    - Introduced a new configurable setting 'api-path' in MkDoxy to allow customization of the output path for auto-generated code documentation.
- **Enhancements**:
    - Updated the API path generation logic to use the new 'api-path' setting combined with 'src-dirs' for better organization of generated documentation.

<!-- Generated by sourcery-ai[bot]: end summary -->