### PR TITLE
Fixes: brief description in detailed if there is no detailed description; change the Detailed Description header level

### DIFF
--- a/mkdoxy/property.py
+++ b/mkdoxy/property.py
@@ -49,7 +49,7 @@ class Property:
             return self.md(plain=True)
 
         def has(self) -> bool:
-            detaileddescription = self.xml.find("detaileddescription")
+            detaileddescription = self.xml.find("briefdescription")
             return len(list(detaileddescription)) > 0
 
     class Includes:

--- a/mkdoxy/templates/member.jinja2
+++ b/mkdoxy/templates/member.jinja2
@@ -68,7 +68,7 @@ Inherited by the following classes:
 {{ templateMemTab.render({'config': {"":""}, 'node': node, 'parent': None, 'title': 'Macros', 'visibility': 'public', 'kinds': ['define'], 'static': False}) }}
 
 {%- if node.has_details %}
-# Detailed Description
+## Detailed Description
 
 {{node.details | use_code_language(node.code_language)}}
 {%- endif %}


### PR DESCRIPTION
This PR fixes two issues:
- #113 
- The level of the "_Detailed Description_" header in the `member.jinja2 ` template. It should be the 2nd level header and not the 1st level header since only the title can be the 1st level header and this breaks the table of contents.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the incorrect usage of brief description in the property module and adjust the header level of 'Detailed Description' in the member.jinja2 template to ensure proper document structure.

Bug Fixes:
- Fix the issue where a brief description was incorrectly used instead of a detailed description in the property module.

Enhancements:
- Change the header level of 'Detailed Description' in the member.jinja2 template from a first-level header to a second-level header to maintain consistency with the document structure.

<!-- Generated by sourcery-ai[bot]: end summary -->