### PR TITLE
Add support for whole spec of doxygen config format

### DIFF
--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -165,7 +165,12 @@ class DoxygenRun:
                     continue
                 match = re.match(pattern, line)
                 if not match:
-                    continue
+                    raise DoxygenCustomConfigNotValid(
+                        f"Invalid line: '{line}'"
+                        f"In custom Doxygen config file: {self.doxyConfigFile}\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/."
+                    )
                 key, operator, value = match.groups()
                 value = value.strip()
                 if operator == '=':

--- a/tests/test_doxyrun.py
+++ b/tests/test_doxyrun.py
@@ -87,3 +87,31 @@ def test_str2dox_dict():
     }
 
     assert result == expected_result
+
+
+def test_str2dox_dict_expanded_config():
+    dox_str = (
+        "# This is a comment \n"
+        "PROJECT_LOGO           =\n"
+        'ABBREVIATE_BRIEF       = "The $name class" \\ \n'
+        '                         is \n'
+        'FILE_PATTERNS          = *.c \n'
+        'FILE_PATTERNS          += *.cc\n'
+    )
+
+    doxygen_run = DoxygenRun(
+        doxygenBinPath="doxygen",
+        doxygenSource="/path/to/source/files",
+        tempDoxyFolder="/path/to/temp/folder",
+        doxyCfgNew={},
+    )
+
+    result = doxygen_run.str2dox_dict(dox_str)
+
+    expected_result = {
+        "PROJECT_LOGO": "",
+        "ABBREVIATE_BRIEF": '"The $name class" is',
+        "FILE_PATTERNS": "*.c *.cc"
+    }
+
+    assert result == expected_result

--- a/tests/test_doxyrun.py
+++ b/tests/test_doxyrun.py
@@ -1,4 +1,5 @@
-from mkdoxy.doxyrun import DoxygenRun
+import pytest
+from mkdoxy.doxyrun import DoxygenCustomConfigNotValid, DoxygenRun
 
 
 def test_dox_dict2str():
@@ -97,6 +98,7 @@ def test_str2dox_dict_expanded_config():
         '                         is \n'
         'FILE_PATTERNS          = *.c \n'
         'FILE_PATTERNS          += *.cc\n'
+        'PREDEFINED             = BUILD_DATE DOXYGEN=1\n'
     )
 
     doxygen_run = DoxygenRun(
@@ -111,7 +113,73 @@ def test_str2dox_dict_expanded_config():
     expected_result = {
         "PROJECT_LOGO": "",
         "ABBREVIATE_BRIEF": '"The $name class" is',
-        "FILE_PATTERNS": "*.c *.cc"
+        "FILE_PATTERNS": "*.c *.cc",
+        "PREDEFINED": "BUILD_DATE DOXYGEN=1"
     }
 
     assert result == expected_result
+
+def test_str2dox_dict_expanded_config_errors():
+    doxygen_run = DoxygenRun(
+        doxygenBinPath="doxygen",
+        doxygenSource="/path/to/source/files",
+        tempDoxyFolder="/path/to/temp/folder",
+        doxyCfgNew={},
+    )
+
+    dox_str = (
+        "ONLY_KEY\n"
+    )
+    error_message = str(f"Invalid line: 'ONLY_KEY'"
+                        f"In custom Doxygen config file: None\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/.")
+
+    with pytest.raises(DoxygenCustomConfigNotValid, match=error_message):
+        doxygen_run.str2dox_dict(dox_str)
+
+    dox_str = (
+        "= ONLY_VALUE\n"
+    )
+    error_message = str(f"Invalid line: '= ONLY_VALUE'"
+                        f"In custom Doxygen config file: None\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/.")
+
+    with pytest.raises(DoxygenCustomConfigNotValid, match=error_message):
+        doxygen_run.str2dox_dict(dox_str)
+
+    dox_str = (
+        "KEY WITH SPACES = VALUE\n"
+    )
+    error_message = str(f"Invalid line: 'KEY WITH SPACES = VALUE'"
+                        f"In custom Doxygen config file: None\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/.")
+
+    with pytest.raises(DoxygenCustomConfigNotValid, match=error_message):
+        doxygen_run.str2dox_dict(dox_str)
+
+    dox_str = (
+        "BAD_OPERATOR := VALUE\n"
+    )
+    error_message = str(f"Invalid line: 'BAD_OPERATOR := VALUE'"
+                        f"In custom Doxygen config file: None\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/.")
+
+    with pytest.raises(DoxygenCustomConfigNotValid, match=error_message):
+        doxygen_run.str2dox_dict(dox_str)
+
+    dox_str = (
+        "BAD_MULTILINE = BAD\n"
+        "                VALUE\n"
+    )
+    error_message = str(f"Invalid line: '                VALUE'"
+                        f"In custom Doxygen config file: None\n"
+                        f"Make sure the file is in standard Doxygen format."
+                        f"Look at https://mkdoxy.kubaandrysek.cz/usage/advanced/.")
+
+    with pytest.raises(DoxygenCustomConfigNotValid, match=error_message):
+        doxygen_run.str2dox_dict(dox_str)
+


### PR DESCRIPTION
Adds support for the complete spec for doxygen config file formats.

Closes #115

## Summary by Sourcery

Add support for the complete specification of Doxygen configuration file formats, including handling of comments and multi-line values. Update the parsing logic to accommodate new operators and patterns, and introduce a test case to validate the expanded configuration parsing.

New Features:
- Add support for parsing the complete specification of Doxygen configuration file formats.

Tests:
- Introduce a new test case to verify the expanded configuration parsing for Doxygen config files.