### PR TITLE
Fix bad anchors in v2

### DIFF
--- a/mkdoxy/constants.py
+++ b/mkdoxy/constants.py
@@ -37,6 +37,7 @@ OVERLOAD_OPERATORS = [
     "operator<<=",
     "operator>>=",
     "operator[]",
+    "operator()",
     "operator*",
     "operator&",
     "operator->",

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -454,7 +454,10 @@ class Node:
     @property
     def name_url_safe(self) -> str:
         name = self.name_tokens[-1]
-        return name.replace(" ", "-").replace("=", "").replace("~", "").lower()
+        return name.replace("=", "").replace("~", "").replace(",", "") \
+                   .replace("<", "").replace(">", "").replace(".", "") \
+                   .strip(' ').replace(" ", "-") \
+                   .lower()
 
     @property
     def anchor(self) -> str:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element as Element
 
@@ -454,10 +455,9 @@ class Node:
     @property
     def name_url_safe(self) -> str:
         name = self.name_tokens[-1]
-        return name.replace("=", "").replace("~", "").replace(",", "") \
-                   .replace("<", "").replace(">", "").replace(".", "") \
-                   .strip(' ').replace(" ", "-") \
-                   .lower()
+        # Strip special characters that do not appear in anchors
+        name = re.sub("[=~.,<>]", "", name)
+        return name.strip(' ').replace(" ", "-").lower()
 
     @property
     def anchor(self) -> str:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -448,12 +448,14 @@ class Node:
         total = 0
         for child in self.parent.children:
             child_refid = child.name.replace(" ", "")
-            # Check if the child is an operator overload by ensuring:
+            # Check if the child is a displayed operator by ensuring:
             # 1. Its identifier is in the predefined OVERLOAD_OPERATORS list.
             # 2. It starts with the expected 'stem' derived from the parent's naming.
-            # 3. It does not start with an extra hyphen (stem+'-') to avoid matching
+            # 3. It does not start with an extra hyphen (stem+'-') to avoid excessive matching.
+            # 4. It is not private.
             if child.is_function and child_refid in OVERLOAD_OPERATORS and \
-                    child_refid.startswith(stem) and not child_refid.startswith(stem+'-'):
+                    child_refid.startswith(stem) and not child_refid.startswith(stem+'-') \
+                    and child._visibility != Visibility.PRIVATE:
                 total += 1
             if child.refid == self._refid:
                 break

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -444,9 +444,12 @@ class Node:
 
     @property
     def operator_num(self) -> int:
+        stem = "operator" + ("-" * self._name.count("-"))
         total = 0
         for child in self.parent.children:
-            if child.is_function and child.name.replace(" ", "") in OVERLOAD_OPERATORS:
+            child_refid = child.name.replace(" ", "")
+            if child.is_function and child_refid in OVERLOAD_OPERATORS and \
+                    child_refid.startswith(stem) and not child_refid.startswith(stem+'-'):
                 total += 1
             if child.refid == self._refid:
                 break
@@ -464,7 +467,10 @@ class Node:
         name = ""
         if self._name.replace(" ", "") in OVERLOAD_OPERATORS:
             num = self.operator_num
-            name = f"operator_{str(self.operator_num - 1)}" if num > 1 else "operator"
+            if self._name.startswith("operator-"):
+                name = f"operator-_{str(num - 1)}" if num > 1 else "operator-"
+            else:
+                name = f"operator_{str(num - 1)}" if num > 1 else "operator"
         elif self.is_overloaded:
             name = f"{self.name_url_safe}-{str(self.overload_num)}{str(self.overload_total)}"
         else:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -448,6 +448,10 @@ class Node:
         total = 0
         for child in self.parent.children:
             child_refid = child.name.replace(" ", "")
+            # Check if the child is an operator overload by ensuring:
+            # 1. Its identifier is in the predefined OVERLOAD_OPERATORS list.
+            # 2. It starts with the expected 'stem' derived from the parent's naming.
+            # 3. It does not start with an extra hyphen (stem+'-') to avoid matching
             if child.is_function and child_refid in OVERLOAD_OPERATORS and \
                     child_refid.startswith(stem) and not child_refid.startswith(stem+'-'):
                 total += 1

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -453,9 +453,13 @@ class Node:
             # 2. It starts with the expected 'stem' derived from the parent's naming.
             # 3. It does not start with an extra hyphen (stem+'-') to avoid excessive matching.
             # 4. It is not private.
-            if child.is_function and child_refid in OVERLOAD_OPERATORS and \
-                    child_refid.startswith(stem) and not child_refid.startswith(stem+'-') \
-                    and child._visibility != Visibility.PRIVATE:
+            if (
+                child.is_function
+                and child_refid in OVERLOAD_OPERATORS
+                and child_refid.startswith(stem)
+                and not child_refid.startswith(stem + "-")
+                and child._visibility != Visibility.PRIVATE
+            ):
                 total += 1
             if child.refid == self._refid:
                 break
@@ -466,7 +470,7 @@ class Node:
         name = self.name_tokens[-1]
         # Strip special characters that do not appear in anchors
         name = re.sub("[=~.,<>]", "", name)
-        return name.strip(' ').replace(" ", "-").lower()
+        return name.strip(" ").replace(" ", "-").lower()
 
     @property
     def anchor(self) -> str:


### PR DESCRIPTION
Fix bad anchors created for:
- `operator()` (missing from `OVERLOAD_OPERATORS`)
- Any operators containing `-` as this character is preserved in the anchor
- Sections with template syntax in the name (e.g. `MyClass<Specialisation, Specialization>`)
- Sections with long names truncated to end with `...`
- Any operator which is also overridden in a `private` zone (where the documentation is not extracted by doxygen)

This fixes #131

## Summary by Sourcery

Correct anchor generation for operators and other section names in Markdown output

Bug Fixes:
- Include operator() in the overload list to generate its anchor
- Exclude private and hyphenated operators from skewing anchor numbering
- Handle section names with template syntax, long names truncated with '...', and hyphens correctly

Enhancements:
- Improve name_url_safe to strip special characters (=, ~, ., ',', '<', '>') before slugification
- Introduce hyphen-aware stem logic for operator overload numbering