### PR TITLE
Fix equation rendering

### DIFF
--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -224,3 +224,22 @@ class MdTable(Md):
                 f.write("|")
             is_first = False
         f.write("\n\n")
+
+
+class MdInlineEquation(Md):
+    def __init__(self, equation: str):
+        self.equation = equation
+
+    def render(self, f: MdRenderer, indent: str):
+        if self.equation:
+            f.write(rf"\({self.equation}\)")
+
+
+class MdBlockEquation(Md):
+    def __init__(self, equation: str):
+        self.equation = equation
+
+    def render(self, f: MdRenderer, indent: str):
+        f.write("\n")
+        f.write(rf"\[{self.equation}\]")
+        f.write("\n")

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -241,5 +241,5 @@ class MdBlockEquation(Md):
 
     def render(self, f: MdRenderer, indent: str):
         f.write("\n")
-        f.write(rf"\[{self.equation}\]")
+        f.write(rf"{indent}\[{self.equation}\]")
         f.write("\n")

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -279,9 +279,9 @@ class XmlParser:
 
             elif item.tag == "emphasis":
                 ret.append(MdItalic(self.paras(item)))
-            elif item.tag == "formula":
-                equation = item.text.strip("$ ")
-                if len(p) == 1 and item.tail is None:
+            elif item.tag == "formula" and item.text:
+                equation = item.text.strip("$").strip()
+                if len(p) == 1 and not item.tail:
                     ret.append(MdBlockEquation(equation))
                 else:
                     ret.append(MdInlineEquation(equation))

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -6,10 +6,12 @@ from mkdoxy.markdown import (
     Code,
     Md,
     MdBlockQuote,
+    MdBlockEquation,
     MdBold,
     MdCodeBlock,
     MdHeader,
     MdImage,
+    MdInlineEquation,
     MdItalic,
     MdLink,
     MdList,
@@ -277,6 +279,12 @@ class XmlParser:
 
             elif item.tag == "emphasis":
                 ret.append(MdItalic(self.paras(item)))
+            elif item.tag == "formula":
+                equation = item.text.strip("$ ")
+                if len(p) == 1 and item.tail is None:
+                    ret.append(MdBlockEquation(equation))
+                else:
+                    ret.append(MdInlineEquation(equation))
 
             if item.tail:
                 if italic:


### PR DESCRIPTION
Fix equation rendering by saving strings from a `<formula>` tag into a `MdInlineEquation` or `MdBlockEquation`. Fixes #133

## Summary by Sourcery

Fix equation rendering by introducing inline and block math nodes and mapping `<formula>` tags to them in the XML parser.

Bug Fixes:
- Restore equation rendering by converting `<formula>` tags into math nodes.

Enhancements:
- Add MdInlineEquation and MdBlockEquation classes for inline and block LaTeX rendering.
- Update XML parser to strip delimiters and choose inline or block equation based on context.