### PR TITLE
Raise warnings for unused configuration keys

### DIFF
--- a/mkdoxy/doxy_config.py
+++ b/mkdoxy/doxy_config.py
@@ -49,6 +49,13 @@ class MkDoxyConfigProject(Config):
     doxy_config_file_force = c.Type(bool, default=False)
     custom_template_dir = c.Optional(c.Type(str))
 
+    def validate(self):
+        failed, warnings = super().validate()
+        unused_keys = set(self.keys()) - self._schema_keys
+        for k in unused_keys.intersection(config_project_legacy.keys()):
+            warnings.append((k, f"Deprecated configuration name: {k} -> {config_project_legacy[k]}"))
+
+        return failed, warnings
 
 class MkDoxyConfig(Config):
     """! Global configuration for the MkDoxy plugin.
@@ -74,6 +81,17 @@ class MkDoxyConfig(Config):
     generate_diagrams = c.Type(bool, default=False)  # generate diagrams
     generate_diagrams_format = c.Choice(("svg", "png", "jpg", "gif"), default="svg")  # diagram format
     generate_diagrams_type = c.Choice(("dot", "uml"), default="dot")  # diagram type
+
+    def validate(self):
+        failed, warnings = super().validate()
+        unused_keys = set(self.keys()) - self._schema_keys
+        for k in unused_keys.intersection(config_scheme_legacy.keys()):
+            warnings.append((k, f"Deprecated configuration name: {k} -> {config_scheme_legacy[k]}"))
+
+        project_warnings = next(s.option_type.warnings for k, s in self._schema if k == 'projects')
+        warnings.extend(project_warnings)
+
+        return failed, warnings
 
 
 # def load_config_by_key(key: str, legacy_key: str, config: Config, legacy: list) -> any:

--- a/mkdoxy/doxy_config.py
+++ b/mkdoxy/doxy_config.py
@@ -51,6 +51,8 @@ class MkDoxyConfigProject(Config):
 
     def validate(self):
         failed, warnings = super().validate()
+
+        # Add a warning for deprecated configuration keys
         unused_keys = set(self.keys()) - self._schema_keys
         for k in unused_keys.intersection(config_project_legacy.keys()):
             warnings.append((k, f"Deprecated configuration name: {k} -> {config_project_legacy[k]}"))
@@ -84,12 +86,14 @@ class MkDoxyConfig(Config):
 
     def validate(self):
         failed, warnings = super().validate()
+
+        # Add a warning for deprecated configuration keys
         unused_keys = set(self.keys()) - self._schema_keys
         for k in unused_keys.intersection(config_scheme_legacy.keys()):
             warnings.append((k, f"Deprecated configuration name: {k} -> {config_scheme_legacy[k]}"))
 
-        project_warnings = next(s.option_type.warnings for k, s in self._schema if k == 'projects')
-        warnings.extend(project_warnings)
+        # Include warnings from sub-config options in mkdoxy.projects
+        warnings.extend(next(s.option_type.warnings for k, s in self._schema if k == 'projects'))
 
         return failed, warnings
 

--- a/mkdoxy/doxy_config.py
+++ b/mkdoxy/doxy_config.py
@@ -59,6 +59,7 @@ class MkDoxyConfigProject(Config):
 
         return failed, warnings
 
+
 class MkDoxyConfig(Config):
     """! Global configuration for the MkDoxy plugin.
     @details New type of global configuration for the MkDoxy plugin. It will replace the old configuration type.
@@ -93,7 +94,7 @@ class MkDoxyConfig(Config):
             warnings.append((k, f"Deprecated configuration name: {k} -> {config_scheme_legacy[k]}"))
 
         # Include warnings from sub-config options in mkdoxy.projects
-        warnings.extend(next(s.option_type.warnings for k, s in self._schema if k == 'projects'))
+        warnings.extend(next(s.option_type.warnings for k, s in self._schema if k == "projects"))
 
         return failed, warnings
 

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -34,7 +34,6 @@ class MkDoxy(BasePlugin[MkDoxyConfig]):
         self.default_template_config = {
             "indent_level": 0,
         }
-        # check deprecated config here
 
     def is_enabled(self) -> bool:
         """! Checks if the plugin is enabled


### PR DESCRIPTION
Raise warnings for unused configuration keys. Raise more explicit warnings for deprecated keys to help with migrating to v2.

## Summary by Sourcery

Add deprecation warnings for unused and legacy configuration keys in both project and global validation, and propagate project-level warnings into the global validator

Enhancements:
- Warn about deprecated project configuration keys during validation
- Warn about deprecated global configuration keys during validation
- Aggregate project sub-config warnings in the global validator

Chores:
- Remove obsolete deprecated config check comment in plugin initialization