### PR TITLE
Add support for @par with title

### DIFF
--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -248,7 +248,11 @@ class XmlParser:
                 ret.extend((Br(), MdBold([Text(SIMPLE_SECTIONS[item.get("kind")])]), Br(), lst))
             elif item.tag == "simplesect":
                 kind = item.get("kind")
-                ret.extend((Br(), MdBold([Text(SIMPLE_SECTIONS[kind])])))
+                title = item.find("title")
+                if title is not None and title.text:
+                    ret.extend((Br(), MdBold(self.paras(title)), Br()))
+                elif kind in SIMPLE_SECTIONS:
+                    ret.extend((Br(), MdBold([Text(SIMPLE_SECTIONS[kind])])))
                 if kind != "see":
                     ret.append(Br())
                 else:

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -249,7 +249,7 @@ class XmlParser:
             elif item.tag == "simplesect":
                 kind = item.get("kind")
                 title = item.find("title")
-                if title is not None and title.text:
+                if title is not None and title.text and title.text.strip():
                     ret.extend((Br(), MdBold(self.paras(title)), Br()))
                 elif kind in SIMPLE_SECTIONS:
                     ret.extend((Br(), MdBold([Text(SIMPLE_SECTIONS[kind])])))


### PR DESCRIPTION
## Change Summary

I wanted to see paragraph sections with custom titles like "Example:" or "Tip:", but the parser was ignoring Doxygen's optional paragraph title.

## Sample usage

Paragraph without title (pre-existing functionality)
```cpp
/*!
 * @par
 * Lorem ipsum dolor sit amet consectetur adipiscing elit.
 */
```

Paragraph with title
```cpp
/*!
 * @par Tip:
 * Lorem ipsum dolor sit amet consectetur adipiscing elit.
 */
```

## Summary by Sourcery

New Features:
- Render user-defined paragraph titles for Doxygen @par sections instead of always using default headings.