### PR TITLE
Git clone support with persistent temp dir, multi-repo handling and configurable insert in nav tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ tests/files/.mkdoxy
 .mkdoxy/
 temp/
 local/
+venv*

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,21 @@
+# feat: Git clone support and automatic nav injection for remote sources
+
+## Summary
+
+Adds the ability to use a remote Git repository as the documentation source for a MkDoxy project. The plugin clones the repository at build time, runs Doxygen against it, and automatically injects the generated API pages into a specified section of the MkDocs navigation.
+
+## Changes
+
+### New features
+
+- **Git clone support** (`git-url`, `git-branch`, `git-recursive` config options): When `git-url` is set for a project, MkDoxy clones the repository at build time using a shallow clone (`depth=1`) and uses it as the source for Doxygen. Submodule recursion can be enabled via `git-recursive`.
+- **Automatic nav injection** (`parent-nav-section` config option): After generating the API docs, the plugin reads the generated `links.md` and injects the resulting nav entries into a named section of the MkDocs `nav` config. The section is located recursively, so it works at any nesting level.
+- **`rewrite_nav()` function**: Parses `links.md`, builds nav entries, and calls `get_navigation()` to rebuild the MkDocs navigation with the new entries inserted.
+- **`cleanup_temp_dir()` helper**: Removes the temporary directory created for the git clone after all projects have been processed.
+
+### Implementation details
+
+- Replaced `TemporaryDirectory` context manager with `tempfile.mkdtemp()` so the cloned repository persists for the full duration of the build.
+- `src-dirs` path is built by joining the clone root with the configured subdirectory; defaults to the clone root if `src-dirs` is not a string.
+- Git clone errors are handled separately for `GitExc.GitCommandError` (with `stderr` extraction) and generic exceptions, both logged and re-raised as `ConfigurationError`. Respects the `ignore-errors` flag.
+

--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -240,8 +240,7 @@ class DoxygenRun:
             stderr=PIPE,
         )
         (doxyBuilder.communicate(self.dox_dict2str(self.doxyCfg).encode("utf-8"))[0].decode().strip())
-        # log.info(self.destinationDir)
-        # log.info(stdout_data)
+        print(f'--------------------------{self.tempDoxyFolder}')
 
     def checkAndRun(self):
         """! Check if the source files have changed since the last run and run Doxygen if they have.

--- a/mkdoxy/doxyrun.py
+++ b/mkdoxy/doxyrun.py
@@ -240,7 +240,6 @@ class DoxygenRun:
             stderr=PIPE,
         )
         (doxyBuilder.communicate(self.dox_dict2str(self.doxyCfg).encode("utf-8"))[0].decode().strip())
-        print(f'--------------------------{self.tempDoxyFolder}')
 
     def checkAndRun(self):
         """! Check if the source files have changed since the last run and run Doxygen if they have.

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -316,7 +316,7 @@ def rewrite_nav(project_name, parent_nav_section, src_dirs, files, config) -> Na
                         return True
         return False
 
-    raw_nav = config.get("nav")
+    raw_nav = config.get("nav") or []
     section_found = find_and_insert(raw_nav, parent_nav_section, nav_entries)
 
     if not section_found:

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -27,13 +27,7 @@ import shutil
 import yaml
 import re
 
-logging.basicConfig(
-    level=logging.DEBUG,  # Set the root logger to DEBUG
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-
 log: logging.Logger = logging.getLogger("mkdocs")
-log.setLevel(logging.DEBUG)
 pluginName: str = "MkDoxy"
 
 

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -57,7 +57,7 @@ def clone_repository(url: str, recursive: bool = False, branch: str = "main") ->
         return str(repo_path)
         
     except GitExc.GitCommandError as e:
-        error_message = f"Git clone failed for {url}: {e.stderr.strip()}"
+        error_message = f"Git clone failed for {url}: {(e.stderr or str(e)).strip()}"
         log.error(error_message)
         raise ConfigurationError(error_message)
         

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -24,6 +24,8 @@ from mkdoxy.xml_parser import XmlParser
 
 import tempfile
 import shutil
+import yaml
+import re
 
 logging.basicConfig(
     level=logging.DEBUG,  # Set the root logger to DEBUG
@@ -75,10 +77,9 @@ class MkDoxy(BasePlugin):
     config_scheme = (
         ("projects", config_options.Type(dict, default={})),
         ("full-doc", config_options.Type(bool, default=True)),
-        ("debug", config_options.Type(bool, default=True)),
+        ("debug", config_options.Type(bool, default=False)),
         ("ignore-errors", config_options.Type(bool, default=False)),
         ("save-api", config_options.Type(str, default="")),
-        ("git-clone", config_options.Type(bool, default=False)),
         ("git-recursive", config_options.Type(bool, default=False)),
         ("enabled", config_options.Type(bool, default=True)),
         (
@@ -99,6 +100,7 @@ class MkDoxy(BasePlugin):
         ("template-dir", config_options.Type(str, default="", required=False)),
         ("git-url", config_options.Type(str, default="")),
         ("git-branch", config_options.Type(str, default="main")),
+        ("parent-nav-section", config_options.Type(str, default="", required=True)),
     )
 
     def is_enabled(self) -> bool:
@@ -203,7 +205,6 @@ class MkDoxy(BasePlugin):
                 project_data.get("doxy-cfg", {}),
                 project_data.get("doxy-cfg-file", ""),
             )
-            # print(f'--------------------------------doxyrun{ls -l}')
             if doxygenRun.checkAndRun():
                 log.info("  -> generating Doxygen files")
             else:
@@ -219,7 +220,7 @@ class MkDoxy(BasePlugin):
             # Print parsed files
             if self.debug:
                 self.doxygen[project_name].printStructure()
-
+            print(f'---------------------- after doxygen and xml parsing')
             # Prepare generator for future use (GeneratorAuto, SnippetGenerator)
             self.generatorBase[project_name] = GeneratorBase(
                 project_data.get("template-dir", ""),
@@ -236,17 +237,25 @@ class MkDoxy(BasePlugin):
                     doxygen=self.doxygen[project_name],
                     useDirectoryUrls=config["use_directory_urls"],
                 )
-
+                print(f'---------------------- after generator auto init')
                 project_config = self.defaultTemplateConfig.copy()
                 project_config.update(project_data)
                 generatorAuto.fullDoc(project_config)
-
+                print(f'---------------------- after generator auto full doc')
                 generatorAuto.summary(project_config)
-
+                print(f'---------------------- after generator auto summary')
                 for file in generatorAuto.fullDocFiles:
+                    print(f'---------------------- adding file to mkdocs: {file}')
                     files.append(file)
-        
+                    print(f'---------------------- file added to mkdocs: {file}')
+            print(f'---------------------- before rewrite_nav')
+            rewrite_nav(project_name, project_data.get("parent-nav-section"), config["site_dir"], mkdocs_config=config, mkdocs_file="mkdocs.nav.yml")
+            print(f'---------------------- after rewrite_nav')
         temp_dir = str(Path(cloned_path).parent)
+        print(f'---------------------- rewwrite_nav')
+        print(f'---------------------- project_name: {config["site_dir"]}')
+        
+        print(f'----------------------after rewrite_nav')
         cleanup_temp_dir(temp_dir)
         return files
 
@@ -285,6 +294,69 @@ class MkDoxy(BasePlugin):
         )
         
         return generatorSnippets.generate()
+
+
+def rewrite_nav(project_name, parent_nav_section, src_dirs, mkdocs_file="mkdocs.nav.yml"):
+    print(f'---------------------- rewrite_nav called with project_name: {project_name}, parent_nav_section: {parent_nav_section}, mkdocs_file: {mkdocs_file}')
+    with open(f'{src_dirs}/assets/.doxy/{project_name}/{project_name}/links.md', 'r') as file:
+        lines = file.read().splitlines()
+    nav_entries = []
+    print(f'---------------------- lines read from links.md: {lines}')
+    pattern = re.compile(r'-\s+\[([^\]]+)\]\(([^)]+)\)')
+ 
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+ 
+        match = pattern.search(line)
+        if not match:
+            continue
+ 
+        title = match.group(1).strip()
+        filename = match.group(2).strip()        
+        path = f"{project_name}/{filename}"        
+ 
+        nav_entries.append({title: path})
+    print(f'---------------------- nav_entries generated from links.md: {nav_entries}')
+    mkdocs_path = Path(mkdocs_file)
+    if mkdocs_path.exists():
+        config = yaml.safe_load(mkdocs_path.read_text(encoding="utf-8")) or {}
+    else:
+        config = {}
+ 
+    nav = config.get("nav") or [{"Home": "index.md"}]
+    print(f'---------------------- nav before: {nav}')
+    def find_and_insert(nav_list: list, target: str, entries: list) -> bool:
+        """Recursively search nav_list for a section named target and extend it."""
+        for item in nav_list:
+            if not isinstance(item, dict):
+                continue
+            for key, value in item.items():
+                # Found the target secti
+                if key == target:
+                    if not isinstance(value, list):
+                        item[key] = []
+                    item[key].extend(entries)
+                    return True
+                # Recurse into nested lists
+                if isinstance(value, list):
+                    if find_and_insert(value, target, entries):
+                        return True
+        return False
+ 
+    section_found = find_and_insert(nav, parent_nav_section, nav_entries)
+ 
+    if not section_found:
+        nav.append({parent_nav_section: nav_entries})
+    print(f'---------------------- nav after: {nav}')
+    config["nav"] = nav
+    mkdocs_path.write_text(
+        yaml.dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+ 
+ 
 
 def cleanup_temp_dir(temp_dir):
     """Remove the temporary directory created by mkdtemp."""

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -170,7 +170,7 @@ class MkDoxy(BasePlugin):
                     log.debug(f"Contents of cloned repository: {os.listdir(cloned_path)}")
                     # Update src-dirs to use cloned repository
                     if isinstance(src_dirs, str):
-                        project_data["src-dirs"] = str(Path(cloned_path)) + '/' + str(src_dirs)
+                        project_data["src-dirs"] = str(Path(cloned_path) / src_dirs)
                     else:
                         project_data["src-dirs"] = str(Path(cloned_path))
                 except Exception as e:
@@ -307,7 +307,7 @@ def rewrite_nav(project_name, parent_nav_section, src_dirs, files, config) -> Na
             for key, value in item.items():
                 if key == target:
                     if not isinstance(value, list):
-                        item[key] = []
+                        item[key] = [value]
                     item[key].extend(entries)
                     return True
                 # Recurse into nested lists

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -149,6 +149,8 @@ class MkDoxy(BasePlugin):
         
         log.info(f"Start plugin {pluginName}")
 
+        temp_dirs_to_cleanup: list[str] = []
+
         for project_name, project_data in self.projects_config.items():
             log.info(f"-> Start project '{project_name}'")
 
@@ -164,6 +166,7 @@ class MkDoxy(BasePlugin):
                         recursive=self.config.get("git-recursive", False),
                         branch=project_data.get("git-branch", "main")
                     )
+                    temp_dirs_to_cleanup.append(str(Path(cloned_path).parent))
                     log.debug(f"Contents of cloned repository: {os.listdir(cloned_path)}")
                     # Update src-dirs to use cloned repository
                     if isinstance(src_dirs, str):
@@ -233,8 +236,8 @@ class MkDoxy(BasePlugin):
                 for file in generatorAuto.fullDocFiles:
                     files.append(file)
             self.new_nav = rewrite_nav(project_name, project_data.get("parent-nav-section"), config["site_dir"], files, config)
-        temp_dir = str(Path(cloned_path).parent)
-        cleanup_temp_dir(temp_dir)
+        for temp_dir in temp_dirs_to_cleanup:
+            cleanup_temp_dir(temp_dir)
         return files
 
     def on_page_markdown(

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -31,10 +31,11 @@ log: logging.Logger = logging.getLogger("mkdocs")
 pluginName: str = "MkDoxy"
 
 
-def clone_repository(url: str, recursive: bool = False) -> str:
+def clone_repository(url: str, recursive: bool = False, branch: str = "main") -> str:
     """! Clone a git repository and return the path
     @param url: Repository URL
     @param recursive: Clone submodules recursively
+    @param branch: Branch to clone
     @return: Path to cloned repository
     """
     try:
@@ -46,7 +47,8 @@ def clone_repository(url: str, recursive: bool = False) -> str:
         clone_opts = {
             'url': url,
             'to_path': repo_path,
-            'depth': 1, 
+            'depth': 1,
+            'branch': branch,
             'recursive': recursive
         }
         
@@ -159,7 +161,8 @@ class MkDoxy(BasePlugin):
                     log.info(f"  -> cloning repository {git_url}")
                     cloned_path = clone_repository(
                         git_url,
-                        recursive=self.config.get("git-recursive", False)
+                        recursive=self.config.get("git-recursive", False),
+                        branch=project_data.get("git-branch", "main")
                     )
                     log.debug(f"Contents of cloned repository: {os.listdir(cloned_path)}")
                     # Update src-dirs to use cloned repository

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -96,7 +96,7 @@ class MkDoxy(BasePlugin):
         ("template-dir", config_options.Type(str, default="", required=False)),
         ("git-url", config_options.Type(str, default="")),
         ("git-branch", config_options.Type(str, default="main")),
-        ("parent-nav-section", config_options.Type(str, default="", required=True)),
+        ("parent-nav-section", config_options.Type(str, default="", required=False)),
     )
     new_nav = None
     def is_enabled(self) -> bool:
@@ -235,7 +235,11 @@ class MkDoxy(BasePlugin):
                 generatorAuto.summary(project_config)
                 for file in generatorAuto.fullDocFiles:
                     files.append(file)
-            self.new_nav = rewrite_nav(project_name, project_data.get("parent-nav-section"), config["site_dir"], files, config)
+            parent_nav_section = project_data.get("parent-nav-section", "")
+            if parent_nav_section:
+                self.new_nav = rewrite_nav(project_name, parent_nav_section, config["site_dir"], files, config)
+            else:
+                log.debug(f"No 'parent-nav-section' set for project '{project_name}', skipping nav injection.")
         for temp_dir in temp_dirs_to_cleanup:
             cleanup_temp_dir(temp_dir)
         return files

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -13,7 +13,7 @@ from mkdocs import exceptions
 from mkdocs.config import Config, base, config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure import files, pages
-
+from mkdocs.structure.nav import Navigation, get_navigation
 from mkdoxy.cache import Cache
 from mkdoxy.doxygen import Doxygen
 from mkdoxy.doxyrun import DoxygenRun
@@ -102,7 +102,7 @@ class MkDoxy(BasePlugin):
         ("git-branch", config_options.Type(str, default="main")),
         ("parent-nav-section", config_options.Type(str, default="", required=True)),
     )
-
+    new_nav = None
     def is_enabled(self) -> bool:
         """! Checks if the plugin is enabled
         @details
@@ -151,7 +151,6 @@ class MkDoxy(BasePlugin):
             "indent_level": 0,
         }
         
-
         log.info(f"Start plugin {pluginName}")
 
         for project_name, project_data in self.projects_config.items():
@@ -172,12 +171,8 @@ class MkDoxy(BasePlugin):
                     # Update src-dirs to use cloned repository
                     if isinstance(src_dirs, str):
                         project_data["src-dirs"] = str(Path(cloned_path)) + '/' + str(src_dirs)
-                    # elif isinstance(src_dirs, list):
-                    #     src_dirs = [str(Path(cloned_path) / d) for d in src_dirs]
                     else:
                         project_data["src-dirs"] = str(Path(cloned_path))
-
-                    print(f'++++++++++++++++++++++++++++++++++projectdata src dir die erste{project_data["src-dirs"]}')
                 except Exception as e:
                     error_msg = f"Failed to clone repository {git_url}: {str(e)}"
                     if self.config["ignore-errors"]:
@@ -185,7 +180,6 @@ class MkDoxy(BasePlugin):
                         continue
                     else:
                         raise exceptions.ConfigurationError(error_msg)
-        print(f'++++++++++++++++++++++++++++++++++projectdata src dir die erste{project_data["src-dirs"]}')
         for project_name, project_data in self.projects_config.items():
             log.info(f"-> Start project '{project_name}'")
 
@@ -196,7 +190,6 @@ class MkDoxy(BasePlugin):
                 tempDirApi = tempDir("", self.config.get("save-api"), project_name)
             else:
                 tempDirApi = tempDir(config["site_dir"], "assets/.doxy/", project_name)
-            print(f'---------------------- projectdata srcdirs: {project_data.get("src-dirs")}')
             # Check src changes -> run Doxygen
             doxygenRun = DoxygenRun(
                 self.config["doxygen-bin-path"],
@@ -220,7 +213,6 @@ class MkDoxy(BasePlugin):
             # Print parsed files
             if self.debug:
                 self.doxygen[project_name].printStructure()
-            print(f'---------------------- after doxygen and xml parsing')
             # Prepare generator for future use (GeneratorAuto, SnippetGenerator)
             self.generatorBase[project_name] = GeneratorBase(
                 project_data.get("template-dir", ""),
@@ -237,25 +229,14 @@ class MkDoxy(BasePlugin):
                     doxygen=self.doxygen[project_name],
                     useDirectoryUrls=config["use_directory_urls"],
                 )
-                print(f'---------------------- after generator auto init')
                 project_config = self.defaultTemplateConfig.copy()
                 project_config.update(project_data)
                 generatorAuto.fullDoc(project_config)
-                print(f'---------------------- after generator auto full doc')
                 generatorAuto.summary(project_config)
-                print(f'---------------------- after generator auto summary')
                 for file in generatorAuto.fullDocFiles:
-                    print(f'---------------------- adding file to mkdocs: {file}')
                     files.append(file)
-                    print(f'---------------------- file added to mkdocs: {file}')
-            print(f'---------------------- before rewrite_nav')
-            rewrite_nav(project_name, project_data.get("parent-nav-section"), config["site_dir"], mkdocs_config=config, mkdocs_file="mkdocs.nav.yml")
-            print(f'---------------------- after rewrite_nav')
+            self.new_nav = rewrite_nav(project_name, project_data.get("parent-nav-section"), config["site_dir"], files, config)
         temp_dir = str(Path(cloned_path).parent)
-        print(f'---------------------- rewwrite_nav')
-        print(f'---------------------- project_name: {config["site_dir"]}')
-        
-        print(f'----------------------after rewrite_nav')
         cleanup_temp_dir(temp_dir)
         return files
 
@@ -294,46 +275,36 @@ class MkDoxy(BasePlugin):
         )
         
         return generatorSnippets.generate()
+    def on_nav(self, nav, config, files):
+        return nav
 
 
-def rewrite_nav(project_name, parent_nav_section, src_dirs, mkdocs_file="mkdocs.nav.yml"):
-    print(f'---------------------- rewrite_nav called with project_name: {project_name}, parent_nav_section: {parent_nav_section}, mkdocs_file: {mkdocs_file}')
+def rewrite_nav(project_name, parent_nav_section, src_dirs, files, config) -> Navigation: 
     with open(f'{src_dirs}/assets/.doxy/{project_name}/{project_name}/links.md', 'r') as file:
         lines = file.read().splitlines()
     nav_entries = []
-    print(f'---------------------- lines read from links.md: {lines}')
     pattern = re.compile(r'-\s+\[([^\]]+)\]\(([^)]+)\)')
- 
+
     for line in lines:
         line = line.strip()
         if not line:
             continue
- 
+
         match = pattern.search(line)
         if not match:
             continue
- 
+
         title = match.group(1).strip()
-        filename = match.group(2).strip()        
+        filename = match.group(2).strip()         
         path = f"{project_name}/{filename}"        
- 
+
         nav_entries.append({title: path})
-    print(f'---------------------- nav_entries generated from links.md: {nav_entries}')
-    mkdocs_path = Path(mkdocs_file)
-    if mkdocs_path.exists():
-        config = yaml.safe_load(mkdocs_path.read_text(encoding="utf-8")) or {}
-    else:
-        config = {}
- 
-    nav = config.get("nav") or [{"Home": "index.md"}]
-    print(f'---------------------- nav before: {nav}')
     def find_and_insert(nav_list: list, target: str, entries: list) -> bool:
-        """Recursively search nav_list for a section named target and extend it."""
+        """Recursively search a raw nav list of dicts for a section named target and extend it."""
         for item in nav_list:
             if not isinstance(item, dict):
                 continue
             for key, value in item.items():
-                # Found the target secti
                 if key == target:
                     if not isinstance(value, list):
                         item[key] = []
@@ -344,19 +315,17 @@ def rewrite_nav(project_name, parent_nav_section, src_dirs, mkdocs_file="mkdocs.
                     if find_and_insert(value, target, entries):
                         return True
         return False
- 
-    section_found = find_and_insert(nav, parent_nav_section, nav_entries)
- 
+
+    raw_nav = config.get("nav")
+    section_found = find_and_insert(raw_nav, parent_nav_section, nav_entries)
+
     if not section_found:
-        nav.append({parent_nav_section: nav_entries})
-    print(f'---------------------- nav after: {nav}')
-    config["nav"] = nav
-    mkdocs_path.write_text(
-        yaml.dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True),
-        encoding="utf-8",
-    )
- 
- 
+        log.warning(f"Parent nav section '{parent_nav_section}' not found in navigation. New entries will not be added.")
+
+    config["nav"] = raw_nav
+    nav = get_navigation(files, config)
+    return nav
+    
 
 def cleanup_temp_dir(temp_dir):
     """Remove the temporary directory created by mkdtemp."""

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -303,28 +303,42 @@ def rewrite_nav(project_name, parent_nav_section, src_dirs, files, config) -> Na
         path = f"{project_name}/{filename}"        
 
         nav_entries.append({title: path})
-    def find_and_insert(nav_list: list, target: str, entries: list) -> bool:
-        """Recursively search a raw nav list of dicts for a section named target and extend it."""
+
+    def find_and_insert_path(nav_list: list, section_path: list[str], entries: list) -> bool:
+        """Traverse a raw nav list following a path of nested section names and insert entries at the end."""
+        if not section_path:
+            return False
+
+        target = section_path[0]
+        remaining = section_path[1:]
+
         for item in nav_list:
             if not isinstance(item, dict):
                 continue
             for key, value in item.items():
                 if key == target:
-                    if not isinstance(value, list):
-                        item[key] = [value]
-                    item[key].extend(entries)
-                    return True
-                # Recurse into nested lists
-                if isinstance(value, list):
-                    if find_and_insert(value, target, entries):
+                    if not remaining:
+                        if not isinstance(value, list):
+                            item[key] = [value]
+                        item[key].extend(entries)
                         return True
+                    if isinstance(value, list):
+                        if find_and_insert_path(value, remaining, entries):
+                            return True
+                
         return False
 
+
+    section_path = [seg.strip() for seg in parent_nav_section.split("::")]
+
     raw_nav = config.get("nav") or []
-    section_found = find_and_insert(raw_nav, parent_nav_section, nav_entries)
+    section_found = find_and_insert_path(raw_nav, section_path, nav_entries)
 
     if not section_found:
-        log.warning(f"Parent nav section '{parent_nav_section}' not found in navigation. New entries will not be added.")
+        log.warning(
+            f"Parent nav section path '{parent_nav_section}' not found in navigation. "
+            f"Searched path: {' -> '.join(section_path)}. New entries will not be added."
+        )
 
     config["nav"] = raw_nav
     nav = get_navigation(files, config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs
+GitPython


### PR DESCRIPTION
## Summary

Adds the ability to use a remote Git repository as the documentation source for a MkDoxy project. The plugin clones the repository at build time, runs Doxygen against it, and automatically injects the generated API pages into a specified section of the MkDocs navigation.

## Changes

### New features

- **Git clone support** (`git-url`, `git-branch`, `git-recursive` config options): When `git-url` is set for a project, MkDoxy clones the repository at build time using a shallow clone (`depth=1`) and uses it as the source for Doxygen. Submodule recursion can be enabled via `git-recursive`.
- **Automatic nav injection** (`parent-nav-section` config option): After generating the API docs, the plugin reads the generated `links.md` and injects the resulting nav entries into a named section of the MkDocs `nav` config. The section is located recursively, so it works at any nesting level.
- **`rewrite_nav()` function**: Parses `links.md`, builds nav entries, and calls `get_navigation()` to rebuild the MkDocs navigation with the new entries inserted.
- **`cleanup_temp_dir()` helper**: Removes the temporary directory created for the git clone after all projects have been processed.

### Implementation details

- Replaced `TemporaryDirectory` context manager with `tempfile.mkdtemp()` so the cloned repository persists for the full duration of the build.
- `src-dirs` path is built by joining the clone root with the configured subdirectory; defaults to the clone root if `src-dirs` is not a string.
- Git clone errors are handled separately for `GitExc.GitCommandError` (with `stderr` extraction) and generic exceptions, both logged and re-raised as `ConfigurationError`. Respects the `ignore-errors` flag.

## Summary by Sourcery

Add support for using remote Git repositories as MkDoxy documentation sources and automatically injecting generated API docs into a configurable section of the MkDocs navigation.

New Features:
- Allow projects to specify a Git repository as their Doxygen source via new git-related configuration options.
- Support optional recursive cloning of Git submodules for project sources.
- Inject generated API documentation pages into a named parent section of the MkDocs navigation by parsing the generated links file.

Enhancements:
- Persist cloned repositories for the duration of the build and clean them up explicitly after processing all projects.
- Improve error handling around Git clone operations, converting failures into configuration errors while respecting the ignore-errors flag.

Build:
- Add GitPython as a dependency for Git repository operations.