### PR TITLE
feat: add C++20 concept support

### DIFF
--- a/demo-projects/animal/concepts.h
+++ b/demo-projects/animal/concepts.h
@@ -1,0 +1,79 @@
+#ifndef EXAMPLE_CONCEPTS_H
+#define EXAMPLE_CONCEPTS_H
+
+#include <type_traits>
+#include <concepts>
+#include <string>
+
+/**
+ * @brief Concept that checks if a type is an animal.
+ * @details This concept verifies that a type T has the required
+ * interface to be considered an animal, including name(), legs(),
+ * and sound() member functions.
+ *
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Animal = requires(T a) {
+    { a.name() } -> std::convertible_to<std::string>;
+    { a.legs() } -> std::convertible_to<int>;
+    { a.sound() } -> std::convertible_to<std::string>;
+};
+
+/**
+ * @brief Concept that checks if a type is printable.
+ * @details This concept verifies that a type T can be converted
+ * to a string representation via a print() method.
+ *
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Printable = requires(T a) {
+    { a.print() } -> std::convertible_to<std::string>;
+};
+
+/**
+ * @brief Concept requiring a type to be both an Animal and Printable.
+ * @details A combined concept that requires a type to satisfy both
+ * the Animal and Printable concepts.
+ *
+ * @tparam T The type to check
+ */
+template <typename T>
+concept PrintableAnimal = Animal<T> && Printable<T>;
+
+/**
+ * @brief Concept for numeric types.
+ * @details Checks that a type is either integral or floating point.
+ *
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Numeric = std::is_arithmetic_v<T>;
+
+/**
+ * @brief Concept for hashable types.
+ * @details Checks that a type can be hashed using std::hash.
+ *
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Hashable = requires(T a) {
+    { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * @brief Function constrained by the Animal concept.
+ * @details This function can only be called with types that satisfy
+ * the Animal concept.
+ *
+ * @tparam T An Animal type
+ * @param animal The animal to describe
+ * @return A string description of the animal
+ */
+template <Animal T>
+std::string describe(const T& animal) {
+    return animal.name() + " has " + std::to_string(animal.legs()) + " legs and says " + animal.sound();
+}
+
+#endif // EXAMPLE_CONCEPTS_H

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,8 @@ nav:
           - "Namespace Member Variables": "animal/namespace_member_variables.md"
           - "Namespace Member Typedefs": "animal/namespace_member_typedefs.md"
           - "Namespace Member Enumerations": "animal/namespace_member_enums.md"
+      - "Concepts":
+          - "Concept List": "animal/concepts.md"
       - "Functions": "animal/functions.md"
       - "Variables": "animal/variables.md"
       - "Macros": "animal/macros.md"

--- a/mkdoxy/constants.py
+++ b/mkdoxy/constants.py
@@ -65,6 +65,7 @@ class Kind(Enum):
     EXAMPLE = "example"
     GROUP = "group"
     INTERFACE = "interface"
+    CONCEPT = "concept"
     SIGNAL = "signal"
     SLOT = "slot"
     PROPERTY = "property"
@@ -89,6 +90,9 @@ class Kind(Enum):
 
     def is_interface(self) -> bool:
         return self == Kind.INTERFACE
+
+    def is_concept(self) -> bool:
+        return self == Kind.CONCEPT
 
     def is_class_or_struct(self) -> bool:
         return self in [Kind.CLASS, Kind.STRUCT, Kind.INTERFACE]
@@ -136,6 +140,7 @@ class Kind(Enum):
             Kind.ENUMVALUE,
             Kind.UNION,
             Kind.INTERFACE,
+            Kind.CONCEPT,
             Kind.FRIEND,
             Kind.SIGNAL,
             Kind.SLOT,
@@ -151,6 +156,7 @@ class Kind(Enum):
             Kind.STRUCT,
             Kind.UNION,
             Kind.INTERFACE,
+            Kind.CONCEPT,
         ]
 
     def is_member(self) -> bool:

--- a/mkdoxy/doxygen.py
+++ b/mkdoxy/doxygen.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from xml.etree import ElementTree
+from typing import Union
 
 from mkdoxy.cache import Cache
 from mkdoxy.constants import Kind, Visibility
@@ -10,10 +11,14 @@ from mkdoxy.xml_parser import XmlParser
 
 log: logging.Logger = logging.getLogger("mkdocs")
 
+SortingCfg = Union[bool, dict[str, bool]]
+
 
 class Doxygen:
-    def __init__(self, index_path: str, parser: XmlParser, cache: Cache):
+    def __init__(self, index_path: str, parser: XmlParser, cache: Cache, sorting_cfg: SortingCfg = True):
         self.debug = parser.debug
+        self.sorting_cfg = sorting_cfg
+
         path_xml = os.path.join(index_path, "index.xml")
         if self.debug:
             log.info(f"Loading XML from: {path_xml}")
@@ -114,8 +119,28 @@ class Doxygen:
                 if child.is_dir:
                     self._fix_parents(child)
 
+    def _should_sort(self, node: Node) -> bool:
+        if isinstance(self.sorting_cfg, bool):
+            return self.sorting_cfg
+
+        if isinstance(self.sorting_cfg, dict):
+            if node.is_class_or_struct:
+                return self.sorting_cfg.get("classes", True)
+            if node.is_namespace:
+                return self.sorting_cfg.get("namespaces", True)
+            if node.is_file or node.is_dir:
+                return self.sorting_cfg.get("files", True)
+            if node.is_group:
+                return self.sorting_cfg.get("groups", True)
+
+            return self.sorting_cfg.get("default", True)
+
+        return True
+
     def _recursive_sort(self, node: Node):
-        node.sort_children()
+        if self._should_sort(node):
+            node.sort_children()
+
         for child in node.children:
             self._recursive_sort(child)
 

--- a/mkdoxy/doxygen.py
+++ b/mkdoxy/doxygen.py
@@ -27,6 +27,7 @@ class Doxygen:
         self.files = Node("root", None, self.ctx, self.parser, None)
         self.pages = Node("root", None, self.ctx, self.parser, None)
         self.examples = Node("root", None, self.ctx, self.parser, None)
+        self.concepts = Node("root", None, self.ctx, self.parser, None)
 
         for compound in xml.findall("compound"):
             kind = Kind.from_str(compound.get("kind"))
@@ -81,6 +82,16 @@ class Doxygen:
                 )
                 node._visibility = Visibility.PUBLIC
                 self.examples.add_child(node)
+            if kind == Kind.CONCEPT:
+                node = Node(
+                    os.path.join(index_path, f"{refid}.xml"),
+                    None,
+                    self.ctx,
+                    self.parser,
+                    self.root,
+                )
+                node._visibility = Visibility.PUBLIC
+                self.concepts.add_child(node)
 
         if self.debug:
             log.info("Deduplicating data... (may take a minute!)")
@@ -96,6 +107,13 @@ class Doxygen:
         for child in self.examples.children.copy():
             self._fix_duplicates(child, self.examples, [Kind.EXAMPLE])
 
+        for child in self.concepts.children.copy():
+            self._fix_duplicates(child, self.concepts, [Kind.CONCEPT])
+
+        # For Doxygen < 1.9.5, concepts are emitted as variables inside file compounds.
+        # After node parsing reclassifies them, collect them into the concepts list.
+        self._collect_concepts_from_files()
+
         self._fix_parents(self.files)
 
         if self.debug:
@@ -105,6 +123,7 @@ class Doxygen:
         self._recursive_sort(self.files)
         self._recursive_sort(self.pages)
         self._recursive_sort(self.examples)
+        self._recursive_sort(self.concepts)
 
     def _fix_parents(self, node: Node):
         if node.is_dir or node.is_root:
@@ -113,6 +132,27 @@ class Doxygen:
                     child._parent = node
                 if child.is_dir:
                     self._fix_parents(child)
+
+    def _collect_concepts_from_files(self):
+        """Collect concept nodes from file/root trees into the concepts list.
+
+        For Doxygen < 1.9.5, concepts are emitted as variable members inside
+        file compounds. After Node parsing reclassifies them as Kind.CONCEPT,
+        this method finds them and adds them to self.concepts so they appear
+        in the concept list and get their own pages.
+        """
+        existing_refids = {c.refid for c in self.concepts.children}
+
+        def _find_concepts(nodes):
+            for node in nodes:
+                if node.kind == Kind.CONCEPT and node.refid not in existing_refids:
+                    existing_refids.add(node.refid)
+                    self.concepts.add_child(node)
+                if node.has_children:
+                    _find_concepts(node.children)
+
+        _find_concepts(self.files.children)
+        _find_concepts(self.root.children)
 
     def _recursive_sort(self, node: Node):
         node.sort_children()
@@ -152,6 +192,11 @@ class Doxygen:
 
         log.info("Print files")
         for node in self.files.children:
+            self.print_node(node, "")
+        print("\n")
+
+        log.info("Print concepts")
+        for node in self.concepts.children:
             self.print_node(node, "")
 
     def print_node(self, node: Node, indent: str):

--- a/mkdoxy/finder.py
+++ b/mkdoxy/finder.py
@@ -48,6 +48,25 @@ class Finder:
     def doxyClass(self, project, className: str):
         return self._doxyParent(project, className, Kind.CLASS)
 
+    def doxyConcept(self, project, conceptName: str):
+        """Find a concept by its fully qualified name."""
+        concepts = recursive_find(self.doxygen[project].root.children, Kind.CONCEPT)
+        # Also search the dedicated concepts list
+        concepts.extend(recursive_find(self.doxygen[project].concepts.children, Kind.CONCEPT))
+        # Deduplicate by refid
+        seen = set()
+        unique_concepts = []
+        for c in concepts:
+            if c.refid not in seen:
+                seen.add(c.refid)
+                unique_concepts.append(c)
+        if unique_concepts:
+            for concept in unique_concepts:
+                if self._normalize(conceptName) == self._normalize(concept.name_long):
+                    return concept
+            return self.listToNames(unique_concepts)
+        return None
+
     def doxyNamespace(self, project, namespace: str):
         return self._doxyParent(project, namespace, Kind.NAMESPACE)
 

--- a/mkdoxy/generatorAuto.py
+++ b/mkdoxy/generatorAuto.py
@@ -73,6 +73,8 @@ class GeneratorAuto:
         self.namespaces(self.doxygen.root.children, defaultTemplateConfig)
         self.classes(self.doxygen.root.children, defaultTemplateConfig)
         self.hierarchy(self.doxygen.root.children, defaultTemplateConfig)
+        self.concepts_page(self.doxygen.concepts.children, defaultTemplateConfig)
+        self.concept_members(self.doxygen.concepts.children, defaultTemplateConfig)
         self.modules(self.doxygen.groups.children, defaultTemplateConfig)
         self.pages(self.doxygen.pages.children, defaultTemplateConfig)
         # self.examples(self.doxygen.examples.children) # TODO examples
@@ -232,6 +234,17 @@ class GeneratorAuto:
         output = self.generatorBase.classes(nodes, config)
         self.save(path, output)
 
+    def concepts_page(self, nodes: [Node], config: dict = None):
+        path = "concepts.md"
+
+        output = self.generatorBase.concepts(nodes, config)
+        self.save(path, output)
+
+    def concept_members(self, nodes: [Node], config: dict = None):
+        for node in nodes:
+            if node.is_concept:
+                self.member(node, config)
+
     def modules(self, nodes: [Node], config: dict = None):
         path = "modules.md"
 
@@ -339,6 +352,12 @@ class GeneratorAuto:
         output_summary += str(" " * (offset + 2) + generate_link("Class List", "annotated.md"))
         for node in self.doxygen.root.children:
             self._generate_recursive(output_summary, node, offset + 4)
+
+        if self.doxygen.concepts.children:
+            output_summary += str(" " * (offset + 2) + generate_link("Concept List", "concepts.md"))
+            for node in self.doxygen.concepts.children:
+                if node.kind.is_concept():
+                    output_summary += str(" " * (offset + 4) + generate_link(f"concept {node.name}", f"{node.refid}.md"))
 
         for key, val in ADDITIONAL_FILES.items():
             output_summary += str(" " * (offset + 2) + generate_link(key, val))

--- a/mkdoxy/generatorBase.py
+++ b/mkdoxy/generatorBase.py
@@ -328,6 +328,22 @@ class GeneratorBase:
         }
         return self.render(template, data)
 
+    def concepts(self, nodes: [Node], config: dict = None):
+        """! Render a concepts list page.
+        @details
+        @param nodes ([Node]): List of concept nodes to render.
+        @param config (dict): Config for the template. (default: None)
+        @return (str): Rendered concepts page.
+        """
+        if config is None:
+            config = {}
+        template, metaConfig = self.loadConfigAndTemplate("concepts")
+        data = {
+            "nodes": nodes,
+            "config": merge_two_dicts(config, metaConfig),
+        }
+        return self.render(template, data)
+
     def _find_base_classes(self, nodes: [Node], derived: Node):
         """! Find base classes of a node.
         @details
@@ -339,7 +355,7 @@ class GeneratorBase:
         for node in nodes:
             if isinstance(node, str):
                 ret.append({"refid": node, "derived": derived})
-            elif node.kind.is_parent() and not node.kind.is_namespace():
+            elif node.kind.is_parent() and not node.kind.is_namespace() and not node.kind.is_concept():
                 bases = node.base_classes
                 if len(bases) == 0:
                     ret.append(node)

--- a/mkdoxy/generatorSnippets.py
+++ b/mkdoxy/generatorSnippets.py
@@ -49,6 +49,8 @@ class GeneratorSnippets:
             "class.index": self.doxyClassIndex,
             "class.hierarchy": self.doxyClassHierarchy,
             "namespace.list": self.doxyNamespaceList,
+            "concept": self.doxyConcept,
+            "concept.list": self.doxyConceptList,
             "file.list": self.doxyFileList,
         }
 
@@ -401,6 +403,37 @@ class GeneratorSnippets:
         nodes = self.doxygen[project].files.children
         self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
         return self.generatorBase[project].fileindex(nodes, config)
+
+    def doxyConcept(self, snippet, project: str, config: dict):
+        errorMsg = self.checkConfig(snippet, project, config, ["name"])
+        if errorMsg:
+            return errorMsg
+
+        node = self.finder.doxyConcept(project, config.get("name"))
+        if node is None:
+            return self.doxyNodeIsNone(project, config, snippet)
+
+        if isinstance(node, Node):
+            self._setLinkPrefixNode(node, self.pageUrlPrefix + project + "/")
+            return self.generatorBase[project].member(node, config)
+        return self.doxyError(
+            project,
+            config,
+            "Incorrect concept configuration",
+            f"Did not find Concept with name: `{config.get('name')}`",
+            "Available concepts:",
+            "\n".join(node),
+            "yaml",
+            snippet,
+        )
+
+    def doxyConceptList(self, snippet, project: str, config):
+        errorMsg = self.checkConfig(snippet, project, config, [])
+        if errorMsg:
+            return errorMsg
+        nodes = self.doxygen[project].concepts.children
+        self._setLinkPrefixNodes(nodes, self.pageUrlPrefix + project + "/")
+        return self.generatorBase[project].concepts(nodes, config)
 
     def doxyNodeIsNone(self, project: str, config: dict, snippet: str) -> str:
         return self.doxyError(

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -161,7 +161,7 @@ class MdItemizedList(Md):
         for child in self.children:
             if not isinstance(child, MdItemizedList):
                 f.write(f"{indent}* ")
-            child.render(f, f"{indent}  ")
+            child.render(f, f"{indent}    ")
 
 
 class MdOrderedList(Md):
@@ -172,7 +172,7 @@ class MdOrderedList(Md):
         f.eol()
         for i, child in enumerate(self.children):
             f.write(f"{indent}{i + 1}. ")
-            child.render(f, indent + "   ")
+            child.render(f, f"{indent}    ")
         f.eol()
 
 

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -152,16 +152,28 @@ class MdLink(Md):
         f.write(f"]({self.url})")
 
 
-class MdList(Md):
+class MdItemizedList(Md):
     def __init__(self, children: List[Md]):
         Md.__init__(self, children)
 
     def render(self, f: MdRenderer, indent: str):
         f.eol()
         for child in self.children:
-            if not isinstance(child, MdList):
+            if not isinstance(child, MdItemizedList):
                 f.write(f"{indent}* ")
             child.render(f, f"{indent}  ")
+
+
+class MdOrderedList(Md):
+    def __init__(self, children: List[Md]):
+        Md.__init__(self, children)
+
+    def render(self, f: MdRenderer, indent: str):
+        f.eol()
+        for i, child in enumerate(self.children):
+            f.write(f"{indent}{i + 1}. ")
+            child.render(f, indent + "   ")
+        f.eol()
 
 
 class MdLine:

--- a/mkdoxy/markdown.py
+++ b/mkdoxy/markdown.py
@@ -93,18 +93,18 @@ class Code:
 
 
 class MdCodeBlock:
-    def __init__(self, lines: List[str]):
+    def __init__(self, lines: List[str], lang: str = ""):
         self.lines = lines
+        self.lang = lang
 
     def append(self, line: str):
         self.lines.append(line)
 
     def render(self, f: MdRenderer, indent: str):
-        f.write("```\n")
+        f.write(f"{indent}```{self.lang}\n")
         for line in self.lines:
-            f.write(line)
-            f.write("\n")
-        f.write("```\n")
+            f.write(f"{indent}{line}\n")
+        f.write(f"{indent}```\n")
 
 
 class MdBlockQuote(Md):

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -8,7 +8,7 @@ from mkdoxy.constants import OVERLOAD_OPERATORS, Kind, Visibility
 from mkdoxy.markdown import escape
 from mkdoxy.project import ProjectContext
 from mkdoxy.property import Property
-from mkdoxy.utils import split_safe
+from mkdoxy.utils import split_safe, lang_from_filepath
 from mkdoxy.xml_parser import XmlParser
 
 log: logging.Logger = logging.getLogger("mkdocs")
@@ -634,7 +634,23 @@ class Node:
 
     @property
     def code_language(self) -> str:
-        return self._language
+        # Try to get it explicitly from the XML node first
+        lang = self._xml.get("language") if self._xml is not None else None
+        if lang:
+            return lang
+
+        # Infer the language from the file extension directly from XML
+        location = self._xml.find("location") if self._xml is not None else None
+        if location is not None and location.get("file"):
+            mapped_lang = lang_from_filepath(location.get("file"))
+            if mapped_lang:
+                return mapped_lang
+
+        # Fall back to the inherited _language property
+        if getattr(self, "_language", None):
+            return self._language
+
+        return ""
 
     @property
     def codeblock(self) -> str:
@@ -703,7 +719,12 @@ class Node:
 
         else:
             code.append(self._definition.plain())
-        return "\n".join(["```", *code, "```"])
+
+        lang = self.code_language.lower()
+        if lang == "c++":
+            lang = "cpp"
+
+        return "\n".join([f"```{lang}", *code, "```"])
 
     @property
     def has_base_classes(self) -> bool:

--- a/mkdoxy/node.py
+++ b/mkdoxy/node.py
@@ -74,6 +74,14 @@ class Node:
             if self.debug:
                 log.info(f"Parsing: {self._refid}")
             self._check_attrs()
+
+            # Doxygen < 1.9.5 emits C++20 concepts as kind="variable" with <type>concept</type>.
+            # Detect and re-classify them as Kind.CONCEPT.
+            if self._kind == Kind.VARIABLE:
+                type_elem = self._xml.find("type")
+                if type_elem is not None and type_elem.text and type_elem.text.strip() == "concept":
+                    self._kind = Kind.CONCEPT
+
             self._title = self._name
 
         self._details = Property.Details(self._xml, parser, self._kind)
@@ -211,6 +219,38 @@ class Node:
                 self._parser,
                 self,
             )
+            child._visibility = Visibility.PUBLIC
+            self.add_child(child)
+
+        for innerconcept in self._xml.findall("innerconcept"):
+            refid = innerconcept.get("refid")
+
+            if self._kind in [Kind.GROUP, Kind.DIR, Kind.FILE, Kind.NAMESPACE]:
+                try:
+                    child = self._cache.get(refid)
+                    self.add_child(child)
+                    continue
+                except Exception:
+                    pass
+
+            try:
+                child = Node(
+                    os.path.join(self._dirname, f"{refid}.xml"),
+                    None,
+                    self.project,
+                    self._parser,
+                    self,
+                )
+            except FileNotFoundError:
+                child = Node(
+                    os.path.join(self._dirname, f"{refid}.xml"),
+                    Element("compounddef"),
+                    self.project,
+                    self._parser,
+                    self,
+                    refid=refid,
+                )
+                child._name = innerconcept.text
             child._visibility = Visibility.PUBLIC
             self.add_child(child)
 
@@ -364,6 +404,10 @@ class Node:
         return self._kind.is_interface()
 
     @property
+    def is_concept(self) -> bool:
+        return self._kind.is_concept()
+
+    @property
     def is_typedef(self) -> bool:
         return self._kind.is_typedef()
 
@@ -508,6 +552,8 @@ class Node:
             return prefix("files.md")
         elif self.is_namespace:
             return prefix("namespaces.md")
+        elif self.is_concept:
+            return prefix("concepts.md")
         else:
             return prefix("annotated.md")
 
@@ -519,6 +565,8 @@ class Node:
             return "FileList"
         elif self.is_namespace:
             return "Namespace List"
+        elif self.is_concept:
+            return "Concept List"
         else:
             return "ClassList"
 
@@ -700,6 +748,15 @@ class Node:
                 code.append(f") {self._initializer.plain()}")
             else:
                 code.append(f"#define {self.name_full_unescaped} {self._initializer.plain()}")
+
+        elif self.is_concept:
+            if self._templateparams.has():
+                code.append(f"template<{self._templateparams.plain()}>")
+            constraint = self._initializer.plain()
+            if constraint:
+                code.append(f"concept {self.name_full_unescaped} = {constraint};")
+            else:
+                code.append(f"concept {self.name_full_unescaped} = /* ... */;")
 
         else:
             code.append(self._definition.plain())

--- a/mkdoxy/plugin.py
+++ b/mkdoxy/plugin.py
@@ -51,6 +51,7 @@ class MkDoxy(BasePlugin):
         ("doxy-cfg", config_options.Type(dict, default={}, required=False)),
         ("doxy-cfg-file", config_options.Type(str, default="", required=False)),
         ("template-dir", config_options.Type(str, default="", required=False)),
+        ("sorting", config_options.Type((bool, dict), default=True)),
     )
 
     def is_enabled(self) -> bool:
@@ -131,7 +132,12 @@ class MkDoxy(BasePlugin):
             parser = XmlParser(cache=cache, debug=self.debug)
 
             # Parse basic structure to recursive Nodes
-            self.doxygen[project_name] = Doxygen(doxygenRun.getOutputFolder(), parser=parser, cache=cache)
+            self.doxygen[project_name] = Doxygen(
+                doxygenRun.getOutputFolder(),
+                parser=parser,
+                cache=cache,
+                sorting_cfg=project_data.get("sorting", True)
+            )
 
             # Print parsed files
             if self.debug:

--- a/mkdoxy/templates/concepts.jinja2
+++ b/mkdoxy/templates/concepts.jinja2
@@ -1,0 +1,22 @@
+{% filter indent(config.get('indent_level', 0), True) %}
+# Concept List
+
+{% if nodes|length > 0 %}
+Here are the concepts with brief descriptions:
+
+{% for node in nodes recursive %}
+{%- if node.is_concept %}
+* **concept** [**{{node.name_short}}**]({{node.url}}) {{node.brief}}
+{%- if node.has_children %}
+  {{- loop(node.children)|indent(4, true) }}
+{%- endif %}
+{%- elif node.is_namespace %}
+{%- if node.has_children %}
+  {{- loop(node.children)|indent(0, true) }}
+{%- endif %}
+{%- endif -%}
+{%- endfor %}
+{% else %}
+No concepts found.
+{% endif %}
+{% endfilter %}

--- a/mkdoxy/templates/memTab.jinja2
+++ b/mkdoxy/templates/memTab.jinja2
@@ -23,6 +23,8 @@ See [{{node.name_long}}]({{node.url}})
 | {{member.kind.value}} | [**{{member.name_long if node.is_group else member.name_short}}**]({{member.url}}) {{member.suffix}}<br>{{member.brief}} |
 {%- elif member.is_class or member.is_interface or member.is_struct -%}
 | {{member.kind.value}} | [**{{member.name_long if node.is_group else member.name_short}}**]({{member.url}}) {{member.suffix}}<br>{{member.brief}} |
+{%- elif member.is_concept -%}
+| concept | [**{{member.name_long if node.is_group else member.name_short}}**]({{member.url}}) {{member.suffix}}<br>{{member.brief}} |
 {%- elif member.is_enum or member.is_function or member.is_variable or member.is_union or member.is_typedef -%}
 | {{member.prefix}} {{member.type}} | [**{{member.name_long if node.is_group else member.name_short}}**]({%- if parent %}{{member.url}}{%- else -%}#{{member.anchor}}{%- endif -%}) {{member.params}} {{member.suffix}}<br>{{member.brief}} |
 {%- else -%}

--- a/mkdoxy/templates/member.jinja2
+++ b/mkdoxy/templates/member.jinja2
@@ -52,6 +52,7 @@ Inherited by the following classes:
 {{ templateMemTab.render({'config': {}, 'node': node, 'parent': None, 'title': 'Modules', 'visibility': 'public', 'kinds': ['group'], 'static': False}) }}
 {{ templateMemTab.render({'config': {}, 'node': node, 'parent': None, 'title': 'Namespaces', 'visibility': 'public', 'kinds': ['namespace'], 'static': False}) }}
 {{ templateMemTab.render({'config': {}, 'node': node, 'parent': None, 'title': 'Classes', 'visibility': 'public', 'kinds': ['class', 'struct', 'interface'], 'static': False}) }}
+{{ templateMemTab.render({'config': {}, 'node': node, 'parent': None, 'title': 'Concepts', 'visibility': 'public', 'kinds': ['concept'], 'static': False}) }}
 
 {%- for visibility in ['public', 'protected'] -%}
 {%- for query in [['types', ['enum', 'union', 'typedef']], ['attributes', ['variable']], ['slots', ['slot']], ['properties', ['property']], ['signals', ['signal']], ['functions', ['function']]] -%}

--- a/mkdoxy/utils.py
+++ b/mkdoxy/utils.py
@@ -118,3 +118,29 @@ def check_enabled_markdown_extensions(config: Config, mkdoxyConfig: Config) -> N
     # if mkdoxyConfig.get("emojis-enabled", False):
     # 	if 'pymdownx.emoji' not in enabled_extensions:
     # 		log.warning("The 'pymdownx.emoji' extension is not enabled. Some emojis may not be rendered correctly. https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#configuration")
+
+
+def lang_from_filepath(filepath: str) -> str:
+    """Extracts and normalizes the programming language from a file path or extension."""
+    if not filepath:
+        return ""
+
+    # Safely extract the extension
+    ext = filepath.split('.')[-1].lower() if '.' in filepath else filepath.lower()
+
+    # Map file extensions to their standard Pygments lexer names
+    ext_map = {
+        "h": "cpp", "hpp": "cpp", "hxx": "cpp", "cpp": "cpp", "cxx": "cpp", "cc": "cpp",
+        "c": "c",
+        "py": "python",
+        "java": "java",
+        "cs": "csharp",
+        "js": "javascript",
+        "ts": "typescript",
+        "rs": "rust",
+        "go": "go",
+        "sh": "bash",
+        "cmake": "cmake"
+    }
+
+    return ext_map.get(ext, ext)

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -14,7 +14,8 @@ from mkdoxy.markdown import (
     MdInlineEquation,
     MdItalic,
     MdLink,
-    MdList,
+    MdItemizedList,
+    MdOrderedList,
     MdParagraph,
     MdRenderer,
     MdTable,
@@ -166,8 +167,17 @@ class XmlParser:
             elif item.tag == "heading":
                 ret.append(MdHeader(int(item.get("level")), self.paras(item)))
 
-            elif item.tag in ["orderedlist", "itemizedlist"]:
-                lst = MdList([])
+            elif item.tag in "itemizedlist":
+                lst = MdItemizedList([])
+                for listitem in item.findall("listitem"):
+                    i = MdParagraph([])
+                    for para in listitem.findall("para"):
+                        i.extend(self.paras(para))
+                    lst.append(i)
+                ret.append(lst)
+
+            elif item.tag == "orderedlist":
+                lst = MdOrderedList([])
                 for listitem in item.findall("listitem"):
                     i = MdParagraph([])
                     for para in listitem.findall("para"):
@@ -232,7 +242,7 @@ class XmlParser:
                     ret.extend(MdParagraph(self.paras(para)) for para in listitem.findall("para"))
             elif item.tag == "parameterlist":
                 parameteritems = item.findall("parameteritem")
-                lst = MdList([])
+                lst = MdItemizedList([])
                 for parameteritem in parameteritems:
                     name = parameteritem.find("parameternamelist").find("parametername")
                     description = parameteritem.find("parameterdescription").findall("para")

--- a/mkdoxy/xml_parser.py
+++ b/mkdoxy/xml_parser.py
@@ -23,7 +23,7 @@ from mkdoxy.markdown import (
     MdTableRow,
     Text,
 )
-from mkdoxy.utils import lookahead
+from mkdoxy.utils import lookahead, lang_from_filepath
 
 # https://www.doxygen.nl/manual/commands.html
 SIMPLE_SECTIONS = {
@@ -103,7 +103,10 @@ class XmlParser:
         ret = []
         # programlisting
         if p.tag == "programlisting":
-            code = MdCodeBlock([])
+            # Extract the language from the Doxygen filename attribute
+            lang = lang_from_filepath(filepath=p.get("filename"))
+
+            code = MdCodeBlock([], lang=lang)
             for codeline in p.findall("codeline"):
                 line = ""
                 for highlight in codeline.findall("highlight"):

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,0 +1,248 @@
+"""Tests for C++20 concept support in MkDoxy."""
+import os
+import tempfile
+import shutil
+import pytest
+
+from mkdoxy.cache import Cache
+from mkdoxy.constants import Kind
+from mkdoxy.doxygen import Doxygen
+from mkdoxy.doxyrun import DoxygenRun
+from mkdoxy.finder import Finder
+from mkdoxy.generatorBase import GeneratorBase
+from mkdoxy.node import Node
+from mkdoxy.utils import recursive_find
+from mkdoxy.xml_parser import XmlParser
+
+
+CONCEPT_HEADER = r"""
+#ifndef EXAMPLE_CONCEPTS_H
+#define EXAMPLE_CONCEPTS_H
+
+#include <type_traits>
+#include <concepts>
+#include <string>
+
+/**
+ * @brief Concept that checks if a type is an animal.
+ * @details This concept verifies that a type T has the required
+ * interface to be considered an animal.
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Animal = requires(T a) {
+    { a.name() } -> std::convertible_to<std::string>;
+    { a.legs() } -> std::convertible_to<int>;
+};
+
+/**
+ * @brief Concept for numeric types.
+ * @tparam T The type to check
+ */
+template <typename T>
+concept Numeric = std::is_arithmetic_v<T>;
+
+/**
+ * @brief A simple function constrained by a concept.
+ * @tparam T An Animal type
+ * @param animal The animal input
+ * @return description string
+ */
+template <Animal T>
+std::string describe(const T& animal) {
+    return animal.name();
+}
+
+#endif
+"""
+
+
+@pytest.fixture(scope="module")
+def doxygen_output():
+    """Generate Doxygen XML output from a concept header file."""
+    tmpdir = tempfile.mkdtemp(prefix="mkdoxy_concept_test_")
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir)
+
+    # Write concept header
+    with open(os.path.join(src_dir, "concepts.h"), "w") as f:
+        f.write(CONCEPT_HEADER)
+
+    # Run Doxygen
+    doxy_run = DoxygenRun(
+        doxygenBinPath="doxygen",
+        doxygenSource=src_dir,
+        tempDoxyFolder=tmpdir,
+        doxyCfgNew={},
+    )
+    doxy_run.checkAndRun()
+
+    xml_dir = doxy_run.getOutputFolder()
+    yield xml_dir
+
+    # Cleanup
+    shutil.rmtree(tmpdir)
+
+
+@pytest.fixture(scope="module")
+def doxygen_parsed(doxygen_output):
+    """Parse Doxygen XML output."""
+    cache = Cache()
+    parser = XmlParser(cache=cache, debug=False)
+    doxygen = Doxygen(doxygen_output, parser=parser, cache=cache)
+    return doxygen
+
+
+class TestKindConcept:
+    """Test that Kind.CONCEPT is properly defined."""
+
+    def test_concept_kind_exists(self):
+        assert Kind.CONCEPT.value == "concept"
+
+    def test_concept_is_language(self):
+        assert Kind.CONCEPT.is_language()
+
+    def test_concept_is_parent(self):
+        assert Kind.CONCEPT.is_parent()
+
+    def test_concept_from_str(self):
+        assert Kind.from_str("concept") == Kind.CONCEPT
+
+    def test_concept_is_concept(self):
+        assert Kind.CONCEPT.is_concept()
+
+    def test_concept_is_not_class(self):
+        assert not Kind.CONCEPT.is_class()
+
+    def test_concept_is_not_class_or_struct(self):
+        assert not Kind.CONCEPT.is_class_or_struct()
+
+
+class TestConceptParsing:
+    """Test that concepts are parsed from Doxygen XML."""
+
+    def test_concepts_list_not_empty(self, doxygen_parsed):
+        """Concepts should be collected into the concepts list."""
+        concepts = doxygen_parsed.concepts.children
+        assert len(concepts) > 0, "Expected at least one concept to be parsed"
+
+    def test_animal_concept_found(self, doxygen_parsed):
+        """The Animal concept should be found."""
+        concept_names = [c.name for c in doxygen_parsed.concepts.children]
+        assert "Animal" in concept_names, f"Expected 'Animal' in {concept_names}"
+
+    def test_numeric_concept_found(self, doxygen_parsed):
+        """The Numeric concept should be found."""
+        concept_names = [c.name for c in doxygen_parsed.concepts.children]
+        assert "Numeric" in concept_names, f"Expected 'Numeric' in {concept_names}"
+
+    def test_concept_kind_is_correct(self, doxygen_parsed):
+        """All concept nodes should have Kind.CONCEPT."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.kind == Kind.CONCEPT, f"Expected {concept.name} to have Kind.CONCEPT, got {concept.kind}"
+
+    def test_concept_has_brief(self, doxygen_parsed):
+        """Concepts should have brief descriptions."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.has_brief, f"Expected {concept.name} to have a brief description"
+
+    def test_concept_has_details(self, doxygen_parsed):
+        """The Animal concept should have detailed description."""
+        animal = None
+        for c in doxygen_parsed.concepts.children:
+            if c.name == "Animal":
+                animal = c
+                break
+        assert animal is not None
+        assert animal.has_details, "Expected Animal concept to have details"
+
+    def test_concept_has_templateparams(self, doxygen_parsed):
+        """Concepts should have template parameters."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.has_templateparams, f"Expected {concept.name} to have template parameters"
+
+    def test_concept_is_concept_property(self, doxygen_parsed):
+        """Node.is_concept should return True for concept nodes."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.is_concept, f"Expected {concept.name}.is_concept to be True"
+
+    def test_concept_is_parent_property(self, doxygen_parsed):
+        """Node.is_parent should return True for concept nodes."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.is_parent, f"Expected {concept.name}.is_parent to be True"
+
+
+class TestConceptFinder:
+    """Test that concepts can be found via the Finder."""
+
+    def test_finder_finds_concept(self, doxygen_parsed):
+        doxygen_dict = {"test": doxygen_parsed}
+        finder = Finder(doxygen_dict)
+        result = finder.doxyConcept("test", "Animal")
+        assert isinstance(result, Node), f"Expected Node, got {type(result)}: {result}"
+        assert result.name == "Animal"
+
+    def test_finder_returns_list_for_unknown(self, doxygen_parsed):
+        doxygen_dict = {"test": doxygen_parsed}
+        finder = Finder(doxygen_dict)
+        result = finder.doxyConcept("test", "NonExistent")
+        assert isinstance(result, list), f"Expected list of suggestions, got {type(result)}"
+
+
+class TestConceptCodeblock:
+    """Test that concept codeblocks are generated correctly."""
+
+    def test_concept_codeblock_contains_concept_keyword(self, doxygen_parsed):
+        """The codeblock should contain the 'concept' keyword."""
+        for concept in doxygen_parsed.concepts.children:
+            codeblock = concept.codeblock
+            assert "concept" in codeblock, f"Expected 'concept' in codeblock, got: {codeblock}"
+
+    def test_concept_codeblock_contains_name(self, doxygen_parsed):
+        """The codeblock should contain the concept name."""
+        for concept in doxygen_parsed.concepts.children:
+            codeblock = concept.codeblock
+            assert concept.name in codeblock, f"Expected '{concept.name}' in codeblock, got: {codeblock}"
+
+
+class TestConceptGeneratorBase:
+    """Test that GeneratorBase can render concept pages."""
+
+    def test_concepts_template_exists(self):
+        """The concepts template should be loaded."""
+        gen = GeneratorBase()
+        assert "concepts" in gen.templates, "Expected 'concepts' template to be loaded"
+
+    def test_concepts_renders(self, doxygen_parsed):
+        """The concepts method should return non-empty output."""
+        gen = GeneratorBase()
+        nodes = doxygen_parsed.concepts.children
+        output = gen.concepts(nodes)
+        assert len(output) > 0, "Expected non-empty concepts output"
+        assert "Concept List" in output, f"Expected 'Concept List' header in output"
+
+    def test_concepts_contains_concept_names(self, doxygen_parsed):
+        """The concepts output should contain concept names."""
+        gen = GeneratorBase()
+        nodes = doxygen_parsed.concepts.children
+        output = gen.concepts(nodes)
+        assert "Animal" in output, f"Expected 'Animal' in concepts output"
+        assert "Numeric" in output, f"Expected 'Numeric' in concepts output"
+
+
+class TestConceptUrls:
+    """Test that concept nodes have correct URL properties."""
+
+    def test_concept_base_url(self, doxygen_parsed):
+        """Concepts should link to concepts.md as their base."""
+        for concept in doxygen_parsed.concepts.children:
+            assert "concepts.md" in concept.base_url, (
+                f"Expected 'concepts.md' in base_url, got: {concept.base_url}"
+            )
+
+    def test_concept_base_name(self, doxygen_parsed):
+        """Concepts should have 'Concept List' as base_name."""
+        for concept in doxygen_parsed.concepts.children:
+            assert concept.base_name == "Concept List", (
+                f"Expected 'Concept List', got: {concept.base_name}"
+            )


### PR DESCRIPTION
Add native support for C++20 concepts in MkDoxy documentation generation.

- Add Kind.CONCEPT to the enum with is_concept(), is_language(), is_parent()
- Parse concept compounds from Doxygen XML (kind="concept" in Doxygen 1.9.5+)
- Auto-detect concepts in older Doxygen (1.9.1-1.9.4) where they appear as kind="variable" with <type>concept</type>, and reclassify them
- Collect concepts from file trees via _collect_concepts_from_files()
- Handle <innerconcept> XML elements inside namespaces
- Generate concept-specific codeblocks (template<...> concept Name = ...;)
- Add Finder.doxyConcept() for concept lookup by name
- Add concepts.jinja2 template for concept list page
- Add concept rows in memTab.jinja2 and concept section in member.jinja2
- Add GeneratorBase.concepts() render method
- Add GeneratorAuto concepts_page() and concept_members() for full-doc mode
- Add 'concept' and 'concept.list' snippet arguments in GeneratorSnippets
- Exclude concepts from class hierarchy in _find_base_classes()
- Add demo concepts.h with 5 example concepts
- Add 25 comprehensive tests covering Kind, parsing, Finder, codeblock, GeneratorBase rendering, and URL generation

Closes: support for C++20 concepts (Doxygen @ref resolution, dedicated pages)

## Summary by Sourcery

Add native support for documenting C++20 concepts throughout MkDoxy, including parsing, navigation, and rendering.

New Features:
- Introduce Kind.CONCEPT with corresponding Node helpers and treat concepts as first-class language and parent entities.
- Parse C++20 concepts from Doxygen XML, including legacy versions where concepts are emitted as variables, and collect them into a dedicated concepts tree.
- Generate concept-specific code blocks and a Concept List page, and expose concepts via new snippet arguments and automatic full-doc generation.
- Add Finder support to resolve and link concepts by name, including suggestions when an exact match is not found.
- Integrate concepts into member tables, navigation structure, and summary output so concepts receive individual documentation pages.

Enhancements:
- Exclude concepts from class hierarchy calculations to keep inheritance views focused on class-like types.

Documentation:
- Add demo C++ header with multiple example concepts to the animal project for documentation generation.

Tests:
- Add a comprehensive test suite covering Kind.CONCEPT behavior, parsing and collection of concepts, Finder lookups, codeblock generation, GeneratorBase concept rendering, and concept URL properties.